### PR TITLE
Add analytics reporting summary API, CSV export, and dashboard panel

### DIFF
--- a/payload-cms/src/endpoints/reportingSummary.ts
+++ b/payload-cms/src/endpoints/reportingSummary.ts
@@ -1,0 +1,148 @@
+import type { PayloadHandler } from 'payload'
+import { getReportingSummary, reportRowsToCsv } from '../utils/analyticsSummary'
+
+const toPct = (value: number) => `${Math.round(value * 1000) / 10}%`
+
+export const reportingSummaryHandler: PayloadHandler = async (req) => {
+  try {
+    const format = req.query?.format === 'csv' ? 'csv' : 'json'
+    const report = await getReportingSummary(req.payload)
+
+    if (format === 'json') {
+      return Response.json(report)
+    }
+
+    const type = typeof req.query?.type === 'string' ? req.query.type : 'all'
+
+    if (type === 'class-completion') {
+      const csv = reportRowsToCsv(
+        report.classCompletion.map((row) => ({
+          class: row.title,
+          attempts: row.total,
+          completed: row.completed,
+          completionRate: toPct(row.completionRate),
+        })),
+        ['class', 'attempts', 'completed', 'completionRate'],
+      )
+      return new Response(csv, {
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': 'attachment; filename="nsf-class-completion.csv"',
+        },
+      })
+    }
+
+    if (type === 'chapter-completion') {
+      const csv = reportRowsToCsv(
+        report.chapterCompletion.map((row) => ({
+          chapter: row.title,
+          attempts: row.total,
+          completed: row.completed,
+          completionRate: toPct(row.completionRate),
+        })),
+        ['chapter', 'attempts', 'completed', 'completionRate'],
+      )
+      return new Response(csv, {
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': 'attachment; filename="nsf-chapter-completion.csv"',
+        },
+      })
+    }
+
+    if (type === 'quiz-mastery') {
+      const csv = reportRowsToCsv(
+        report.quizMasteryDistribution.map((row) => ({
+          scoreBand: row.label,
+          attempts: row.count,
+          percentage: toPct(row.percentage),
+        })),
+        ['scoreBand', 'attempts', 'percentage'],
+      )
+      return new Response(csv, {
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': 'attachment; filename="nsf-quiz-mastery.csv"',
+        },
+      })
+    }
+
+    if (type === 'engagement-wow') {
+      const csv = reportRowsToCsv(
+        report.weeklyEngagement.map((row) => ({
+          weekStart: row.weekStart,
+          activeStudents: row.activeStudents,
+          weekOverWeekChange: row.weekOverWeekChange == null ? 'N/A' : toPct(row.weekOverWeekChange),
+        })),
+        ['weekStart', 'activeStudents', 'weekOverWeekChange'],
+      )
+      return new Response(csv, {
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': 'attachment; filename="nsf-weekly-engagement.csv"',
+        },
+      })
+    }
+
+    const lines = [
+      'NSF CURE SBP Analytics Summary',
+      `Generated At,${report.generatedAt}`,
+      '',
+      'Class Completion',
+      reportRowsToCsv(
+        report.classCompletion.map((row) => ({
+          class: row.title,
+          attempts: row.total,
+          completed: row.completed,
+          completionRate: toPct(row.completionRate),
+        })),
+        ['class', 'attempts', 'completed', 'completionRate'],
+      ),
+      '',
+      'Chapter Completion',
+      reportRowsToCsv(
+        report.chapterCompletion.map((row) => ({
+          chapter: row.title,
+          attempts: row.total,
+          completed: row.completed,
+          completionRate: toPct(row.completionRate),
+        })),
+        ['chapter', 'attempts', 'completed', 'completionRate'],
+      ),
+      '',
+      'Quiz Mastery Distribution',
+      reportRowsToCsv(
+        report.quizMasteryDistribution.map((row) => ({
+          scoreBand: row.label,
+          attempts: row.count,
+          percentage: toPct(row.percentage),
+        })),
+        ['scoreBand', 'attempts', 'percentage'],
+      ),
+      '',
+      'Weekly Engagement',
+      reportRowsToCsv(
+        report.weeklyEngagement.map((row) => ({
+          weekStart: row.weekStart,
+          activeStudents: row.activeStudents,
+          weekOverWeekChange: row.weekOverWeekChange == null ? 'N/A' : toPct(row.weekOverWeekChange),
+        })),
+        ['weekStart', 'activeStudents', 'weekOverWeekChange'],
+      ),
+    ]
+
+    return new Response(lines.join('\n'), {
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': 'attachment; filename="nsf-reporting-summary.csv"',
+      },
+    })
+  } catch {
+    return Response.json(
+      {
+        error: 'Unable to generate reporting summary.',
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/payload-cms/src/payload.config.ts
+++ b/payload-cms/src/payload.config.ts
@@ -38,6 +38,7 @@ import { previewUrlHandler } from './endpoints/previewUrl'
 import { confirmEmailHandler, requestEmailConfirmationHandler } from './endpoints/emailConfirmation'
 import { logoutAllSessionsHandler } from './endpoints/logoutAll'
 import { accountsMeHandler } from './endpoints/accountsMe'
+import { reportingSummaryHandler } from './endpoints/reportingSummary'
 // Uses the generated import map entry for the dashboard view component
 const StaffDashboardView: PayloadComponent = {
   path: '@/views/StaffDashboardView#default',
@@ -234,6 +235,11 @@ export default buildConfig({
       path: '/accounts/logout-all',
       method: 'post',
       handler: logoutAllSessionsHandler,
+    },
+    {
+      path: '/analytics/reporting-summary',
+      method: 'get',
+      handler: reportingSummaryHandler,
     },
   ],
 })

--- a/payload-cms/src/utils/analyticsSummary.ts
+++ b/payload-cms/src/utils/analyticsSummary.ts
@@ -1,0 +1,233 @@
+import type { Payload } from 'payload'
+
+type CompletionSummary = {
+  id: string
+  title: string
+  total: number
+  completed: number
+  completionRate: number
+}
+
+type MasteryBand = {
+  label: string
+  min: number
+  max: number
+  count: number
+  percentage: number
+}
+
+type WeeklyEngagement = {
+  weekStart: string
+  activeStudents: number
+  weekOverWeekChange: number | null
+}
+
+type ReportingSummary = {
+  classCompletion: CompletionSummary[]
+  chapterCompletion: CompletionSummary[]
+  quizMasteryDistribution: MasteryBand[]
+  weeklyEngagement: WeeklyEngagement[]
+  generatedAt: string
+}
+
+const MASTERY_BANDS = [
+  { label: '0-59%', min: 0, max: 0.6 },
+  { label: '60-69%', min: 0.6, max: 0.7 },
+  { label: '70-79%', min: 0.7, max: 0.8 },
+  { label: '80-89%', min: 0.8, max: 0.9 },
+  { label: '90-100%', min: 0.9, max: 1.000_001 },
+]
+
+const toId = (value: unknown): string | null => {
+  if (typeof value === 'string' || typeof value === 'number') return String(value)
+  if (typeof value === 'object' && value !== null && 'id' in value) {
+    const id = (value as { id?: unknown }).id
+    if (typeof id === 'string' || typeof id === 'number') return String(id)
+  }
+  return null
+}
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}
+
+const normalizeScore = (attempt: { score?: unknown; maxScore?: unknown }) => {
+  const score = toNumber(attempt.score)
+  if (score == null) return null
+  const maxScore = toNumber(attempt.maxScore)
+  if (maxScore != null && maxScore > 0) {
+    return Math.max(0, Math.min(1, score / maxScore))
+  }
+  if (score <= 1) return Math.max(0, Math.min(1, score))
+  return Math.max(0, Math.min(1, score / 100))
+}
+
+const getUtcWeekStart = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return null
+  const day = parsed.getUTCDay()
+  const offset = (day + 6) % 7
+  parsed.setUTCDate(parsed.getUTCDate() - offset)
+  parsed.setUTCHours(0, 0, 0, 0)
+  return parsed.toISOString().slice(0, 10)
+}
+
+const findAllDocs = async (
+  payload: Payload,
+  collection: 'classes' | 'chapters' | 'lesson-progress' | 'quiz-attempts',
+) => {
+  const docs: Record<string, unknown>[] = []
+  let page = 1
+  let hasNextPage = true
+
+  while (hasNextPage) {
+    const result = await payload.find({
+      collection,
+      depth: 0,
+      limit: 500,
+      page,
+      sort: 'id',
+    })
+
+    docs.push(...(result.docs as Record<string, unknown>[]))
+    hasNextPage = Boolean(result.hasNextPage)
+    page += 1
+  }
+
+  return docs
+}
+
+export const getReportingSummary = async (payload: Payload): Promise<ReportingSummary> => {
+  const [classes, chapters, lessonProgress, quizAttempts] = await Promise.all([
+    findAllDocs(payload, 'classes'),
+    findAllDocs(payload, 'chapters'),
+    findAllDocs(payload, 'lesson-progress'),
+    findAllDocs(payload, 'quiz-attempts'),
+  ])
+
+  const classTitleById = new Map<string, string>()
+  classes.forEach((item) => {
+    const id = toId(item.id)
+    if (!id) return
+    const title = typeof item.title === 'string' && item.title.trim() ? item.title.trim() : `Class ${id}`
+    classTitleById.set(id, title)
+  })
+
+  const chapterTitleById = new Map<string, string>()
+  chapters.forEach((item) => {
+    const id = toId(item.id)
+    if (!id) return
+    const title = typeof item.title === 'string' && item.title.trim() ? item.title.trim() : `Chapter ${id}`
+    chapterTitleById.set(id, title)
+  })
+
+  const classTotals = new Map<string, { total: number; completed: number }>()
+  const chapterTotals = new Map<string, { total: number; completed: number }>()
+  const weeklyUsers = new Map<string, Set<string>>()
+
+  lessonProgress.forEach((item) => {
+    const classId = toId(item.class)
+    const chapterId = toId(item.chapter)
+    const userId = toId(item.user)
+    const isCompleted = Boolean(item.completed)
+
+    if (classId) {
+      const current = classTotals.get(classId) ?? { total: 0, completed: 0 }
+      current.total += 1
+      if (isCompleted) current.completed += 1
+      classTotals.set(classId, current)
+    }
+
+    if (chapterId) {
+      const current = chapterTotals.get(chapterId) ?? { total: 0, completed: 0 }
+      current.total += 1
+      if (isCompleted) current.completed += 1
+      chapterTotals.set(chapterId, current)
+    }
+
+    const weekStart = getUtcWeekStart(item.updatedAt)
+    if (weekStart && userId) {
+      const set = weeklyUsers.get(weekStart) ?? new Set<string>()
+      set.add(userId)
+      weeklyUsers.set(weekStart, set)
+    }
+  })
+
+  const classCompletion = Array.from(classTotals.entries())
+    .map(([id, totals]) => ({
+      id,
+      title: classTitleById.get(id) ?? `Class ${id}`,
+      total: totals.total,
+      completed: totals.completed,
+      completionRate: totals.total ? totals.completed / totals.total : 0,
+    }))
+    .sort((a, b) => b.completionRate - a.completionRate)
+
+  const chapterCompletion = Array.from(chapterTotals.entries())
+    .map(([id, totals]) => ({
+      id,
+      title: chapterTitleById.get(id) ?? `Chapter ${id}`,
+      total: totals.total,
+      completed: totals.completed,
+      completionRate: totals.total ? totals.completed / totals.total : 0,
+    }))
+    .sort((a, b) => b.completionRate - a.completionRate)
+
+  const scoredAttempts = quizAttempts
+    .map((item) => normalizeScore(item as { score?: unknown; maxScore?: unknown }))
+    .filter((value): value is number => value != null)
+
+  const quizMasteryDistribution: MasteryBand[] = MASTERY_BANDS.map((band) => {
+    const count = scoredAttempts.filter((score) => score >= band.min && score < band.max).length
+    const percentage = scoredAttempts.length ? count / scoredAttempts.length : 0
+    return { ...band, count, percentage }
+  })
+
+  const orderedWeeks = Array.from(weeklyUsers.keys()).sort()
+  const last8Weeks = orderedWeeks.slice(-8)
+  const weeklyEngagement: WeeklyEngagement[] = []
+  let previousCount: number | null = null
+
+  last8Weeks.forEach((weekStart) => {
+    const activeStudents = weeklyUsers.get(weekStart)?.size ?? 0
+    let weekOverWeekChange: number | null = null
+    if (previousCount != null && previousCount > 0) {
+      weekOverWeekChange = (activeStudents - previousCount) / previousCount
+    }
+    weeklyEngagement.push({ weekStart, activeStudents, weekOverWeekChange })
+    previousCount = activeStudents
+  })
+
+  return {
+    classCompletion,
+    chapterCompletion,
+    quizMasteryDistribution,
+    weeklyEngagement,
+    generatedAt: new Date().toISOString(),
+  }
+}
+
+export const reportRowsToCsv = (
+  rows: Array<Record<string, string | number>>,
+  headers: string[],
+): string => {
+  const escape = (value: string | number) => {
+    const stringValue = String(value)
+    if (stringValue.includes(',') || stringValue.includes('"') || stringValue.includes('\n')) {
+      return `"${stringValue.replace(/"/g, '""')}"`
+    }
+    return stringValue
+  }
+
+  const lines = [headers.join(',')]
+  rows.forEach((row) => {
+    lines.push(headers.map((header) => escape(row[header] ?? '')).join(','))
+  })
+  return lines.join('\n')
+}

--- a/payload-cms/src/views/StaffDashboardView.tsx
+++ b/payload-cms/src/views/StaffDashboardView.tsx
@@ -2,6 +2,7 @@ import type { AdminViewServerProps } from 'payload'
 import { Gutter } from '@payloadcms/ui'
 import React from 'react'
 import Link from 'next/link'
+import { getReportingSummary } from '../utils/analyticsSummary'
 
 const cppGold = 'var(--cpp-muted)'
 const cppInk = 'var(--cpp-ink)'
@@ -186,6 +187,18 @@ const StaffDashboardContent = ({
     lowCompletion: { id: string | number; title: string; rate: number }[]
     highQuestions: { id: string | number; title: string; count: number }[]
     lowHelpfulness: { id: string | number; title: string; rating: number }[]
+  }
+  reporting: {
+    classCompletion: { id: string; title: string; total: number; completed: number; completionRate: number }[]
+    chapterCompletion: {
+      id: string
+      title: string
+      total: number
+      completed: number
+      completionRate: number
+    }[]
+    quizMasteryDistribution: { label: string; count: number; percentage: number }[]
+    weeklyEngagement: { weekStart: string; activeStudents: number; weekOverWeekChange: number | null }[]
   }
 }) => (
   <Gutter>
@@ -703,6 +716,103 @@ const StaffDashboardContent = ({
             </div>
           </div>
         </div>
+        <div style={sectionLabelStyle}>NSF reporting summary</div>
+        <div style={{ ...contentBoxStyle }}>
+          <div
+            style={{
+              display: 'grid',
+              gap: 12,
+              gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+            }}
+          >
+            <div style={contentHealthCardStyle}>
+              <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--cpp-ink)' }}>
+                Completion by class
+              </div>
+              <ul style={{ marginTop: 10, display: 'grid', gap: 8 }}>
+                {reporting.classCompletion.slice(0, 5).map((item) => (
+                  <li key={item.id}>
+                    <div style={{ color: 'var(--cpp-ink)', fontWeight: 600 }}>{item.title}</div>
+                    <div style={{ fontSize: 12, color: 'var(--cpp-muted)' }}>
+                      {Math.round(item.completionRate * 100)}% ({item.completed}/{item.total})
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div style={contentHealthCardStyle}>
+              <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--cpp-ink)' }}>
+                Completion by chapter
+              </div>
+              <ul style={{ marginTop: 10, display: 'grid', gap: 8 }}>
+                {reporting.chapterCompletion.slice(0, 5).map((item) => (
+                  <li key={item.id}>
+                    <div style={{ color: 'var(--cpp-ink)', fontWeight: 600 }}>{item.title}</div>
+                    <div style={{ fontSize: 12, color: 'var(--cpp-muted)' }}>
+                      {Math.round(item.completionRate * 100)}% ({item.completed}/{item.total})
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div style={contentHealthCardStyle}>
+              <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--cpp-ink)' }}>
+                Quiz mastery distribution
+              </div>
+              <ul style={{ marginTop: 10, display: 'grid', gap: 8 }}>
+                {reporting.quizMasteryDistribution.map((item) => (
+                  <li key={item.label}>
+                    <div style={{ color: 'var(--cpp-ink)', fontWeight: 600 }}>{item.label}</div>
+                    <div style={{ fontSize: 12, color: 'var(--cpp-muted)' }}>
+                      {item.count} attempts ({Math.round(item.percentage * 100)}%)
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div style={contentHealthCardStyle}>
+              <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--cpp-ink)' }}>
+                Week-over-week engagement
+              </div>
+              <ul style={{ marginTop: 10, display: 'grid', gap: 8 }}>
+                {reporting.weeklyEngagement.slice(-5).map((item) => (
+                  <li key={item.weekStart}>
+                    <div style={{ color: 'var(--cpp-ink)', fontWeight: 600 }}>{item.weekStart}</div>
+                    <div style={{ fontSize: 12, color: 'var(--cpp-muted)' }}>
+                      {item.activeStudents} active students{' '}
+                      {item.weekOverWeekChange == null
+                        ? '(baseline)'
+                        : `(${item.weekOverWeekChange >= 0 ? '+' : ''}${Math.round(item.weekOverWeekChange * 100)}% WoW)`}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+          <div style={{ marginTop: 12, display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            <a href="/api/analytics/reporting-summary?format=csv" style={{ textDecoration: 'none' }}>
+              <div style={heroPrimaryStyle} className="dashboard-chip dashboard-chip--primary">
+                Download NSF summary CSV
+              </div>
+            </a>
+            <a
+              href="/api/analytics/reporting-summary?format=csv&type=class-completion"
+              style={{ textDecoration: 'none' }}
+            >
+              <div style={heroSecondaryStyle} className="dashboard-chip dashboard-chip--secondary">
+                Class completion CSV
+              </div>
+            </a>
+            <a
+              href="/api/analytics/reporting-summary?format=csv&type=quiz-mastery"
+              style={{ textDecoration: 'none' }}
+            >
+              <div style={heroSecondaryStyle} className="dashboard-chip dashboard-chip--secondary">
+                Quiz mastery CSV
+              </div>
+            </a>
+          </div>
+        </div>
         <div style={sectionLabelStyle}>Content health</div>
         <div style={{ ...contentBoxStyle }}>
           <div
@@ -840,6 +950,24 @@ export default async function StaffDashboardView({
     lowCompletion: [] as { id: string | number; title: string; rate: number }[],
     highQuestions: [] as { id: string | number; title: string; count: number }[],
     lowHelpfulness: [] as { id: string | number; title: string; rating: number }[],
+  }
+  let reporting = {
+    classCompletion: [] as {
+      id: string
+      title: string
+      total: number
+      completed: number
+      completionRate: number
+    }[],
+    chapterCompletion: [] as {
+      id: string
+      title: string
+      total: number
+      completed: number
+      completionRate: number
+    }[],
+    quizMasteryDistribution: [] as { label: string; count: number; percentage: number }[],
+    weeklyEngagement: [] as { weekStart: string; activeStudents: number; weekOverWeekChange: number | null }[],
   }
 
   try {
@@ -1093,6 +1221,17 @@ export default async function StaffDashboardView({
     contentHealth = { lowCompletion: [], highQuestions: [], lowHelpfulness: [] }
   }
 
+  try {
+    reporting = await getReportingSummary(payload)
+  } catch {
+    reporting = {
+      classCompletion: [],
+      chapterCompletion: [],
+      quizMasteryDistribution: [],
+      weeklyEngagement: [],
+    }
+  }
+
   const stats = {
     accounts: accountsCount,
     unanswered: unansweredCount,
@@ -1108,6 +1247,7 @@ export default async function StaffDashboardView({
       user={user}
       stats={stats}
       contentHealth={contentHealth}
+      reporting={reporting}
     />
   )
 }


### PR DESCRIPTION
### Motivation
- Provide a consolidated analytics summary (class/chapter completion, quiz mastery, weekly engagement) for NSF CURE SBP and make it available to staff via the admin dashboard. 
- Allow administrators to download CSV exports for the full summary or targeted slices (class completion, chapter completion, quiz mastery, weekly engagement). 

### Description
- Added `src/utils/analyticsSummary.ts` which computes `getReportingSummary` from `classes`, `chapters`, `lesson-progress`, and `quiz-attempts`, and added `reportRowsToCsv` for CSV formatting. 
- Added a new GET endpoint handler `src/endpoints/reportingSummary.ts` that returns JSON or CSV and supports `?format=csv` and `?type=` query params and proper CSV `Content-Disposition` headers. 
- Registered the route in `payload.config.ts` at `/analytics/reporting-summary`. 
- Updated `src/views/StaffDashboardView.tsx` to import and call `getReportingSummary`, render a new "NSF reporting summary" panel with top items and download links, and pass `reporting` data into the dashboard component. 

### Testing
- No automated tests were added or modified for this change, and no automated test runs were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7db96a168832da3d76f3d5e191066)