### PR TITLE
Fix Next.js lint failures in staff dashboard build

### DIFF
--- a/payload-cms/src/migrations/20260212_161835_add_classrooms_and_memberships.ts
+++ b/payload-cms/src/migrations/20260212_161835_add_classrooms_and_memberships.ts
@@ -1,6 +1,6 @@
 import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
 
-export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+export async function up({ db, payload: _payload, req: _req }: MigrateUpArgs): Promise<void> {
   await db.execute(sql`
    DO $$ BEGIN CREATE TYPE "public"."enum_lessons_blocks_section_block_size" AS ENUM('sm', 'md', 'lg'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
   DO $$ BEGIN CREATE TYPE "public"."enum__lessons_v_blocks_section_block_size" AS ENUM('sm', 'md', 'lg'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
@@ -695,7 +695,7 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_lesson_feedback_id_idx" ON "payload_locked_documents_rels" USING btree ("lesson_feedback_id");`)
 }
 
-export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+export async function down({ db, payload: _payload, req: _req }: MigrateDownArgs): Promise<void> {
   await db.execute(sql`
    ALTER TABLE "lessons_blocks_section_block" DISABLE ROW LEVEL SECURITY;
   ALTER TABLE "lessons_blocks_quiz_block" DISABLE ROW LEVEL SECURITY;

--- a/payload-cms/src/views/StaffDashboardView.tsx
+++ b/payload-cms/src/views/StaffDashboardView.tsx
@@ -706,27 +706,27 @@ const StaffDashboardContent = ({
             </div>
           </div>
           <div style={{ marginTop: 12, display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-            <a href="/api/analytics/reporting-summary?format=csv" style={{ textDecoration: 'none' }}>
+            <Link href="/api/analytics/reporting-summary?format=csv" style={{ textDecoration: 'none' }}>
               <div style={heroPrimaryStyle} className="dashboard-chip dashboard-chip--primary">
                 Download NSF summary CSV
               </div>
-            </a>
-            <a
+            </Link>
+            <Link
               href="/api/analytics/reporting-summary?format=csv&type=class-completion"
               style={{ textDecoration: 'none' }}
             >
               <div style={heroSecondaryStyle} className="dashboard-chip dashboard-chip--secondary">
                 Class completion CSV
               </div>
-            </a>
-            <a
+            </Link>
+            <Link
               href="/api/analytics/reporting-summary?format=csv&type=quiz-mastery"
               style={{ textDecoration: 'none' }}
             >
               <div style={heroSecondaryStyle} className="dashboard-chip dashboard-chip--secondary">
                 Quiz mastery CSV
               </div>
-            </a>
+            </Link>
           </div>
         </div>
         <div style={sectionLabelStyle}>Content health</div>


### PR DESCRIPTION
### Motivation
- Next.js build was failing due to `no-html-link-for-pages` lint errors from using raw `<a>` for internal routes and `@typescript-eslint/no-unused-vars` warnings in a migration file.

### Description
- Replace internal analytics CSV anchor elements with `Link` from `next/link` in `payload-cms/src/views/StaffDashboardView.tsx` to satisfy Next.js internal-navigation lint rules.
- Prefix intentionally unused migration arguments with `_` in `payload-cms/src/migrations/20260212_161835_add_classrooms_and_memberships.ts` to silence `@typescript-eslint/no-unused-vars` warnings.
- Updates are limited to `payload-cms/src/views/StaffDashboardView.tsx` and `payload-cms/src/migrations/20260212_161835_add_classrooms_and_memberships.ts` and include related formatting adjustments.

### Testing
- Ran `pnpm run build` in `payload-cms` which failed in this environment because `cross-env` was not available and `node_modules` were missing; build did not complete.
- Ran `pnpm install` which failed due to a `403` when fetching a private package (`@payloadcms/db-postgres`) from the registry in this environment, so dependencies could not be installed and a full build could not be validated.
- Verified source edits and committed the changes locally using `git` and inspected the diff to confirm the intended modifications were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e06a1950832d96acfba1e3d6df31)