### PR TITLE
Fix Payload docs type cast in analytics summary pagination

### DIFF
--- a/payload-cms/src/utils/analyticsSummary.ts
+++ b/payload-cms/src/utils/analyticsSummary.ts
@@ -95,7 +95,7 @@ const findAllDocs = async (
       sort: 'id',
     })
 
-    docs.push(...(result.docs as Record<string, unknown>[]))
+    docs.push(...(result.docs as unknown as Record<string, unknown>[]))
     hasNextPage = Boolean(result.hasNextPage)
     page += 1
   }


### PR DESCRIPTION
### Motivation
- Fix a TypeScript error seen during the Next.js production build where casting `result.docs` directly to `Record<string, unknown>[]` was rejected by the compiler.

### Description
- Update `payload-cms/src/utils/analyticsSummary.ts` to cast `result.docs` via `unknown` before `Record<string, unknown>[]`, i.e. change `result.docs as Record<string, unknown>[]` to `result.docs as unknown as Record<string, unknown>[]` to satisfy the type checker.

### Testing
- Ran `pnpm run build` in `payload-cms`, but the build could not complete because `node_modules` were not installed and `cross-env` was missing, so local build verification did not succeed.
- Ran `pnpm install`, which failed with `ERR_PNPM_FETCH_403` while fetching `@payloadcms/db-postgres` due to missing npm authorization headers, preventing full dependency installation and build validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e1dd71f0832d929f58199005edc8)