### PR TITLE
Add lesson_bookmarks relation columns, include migration, and minor TS/dashboard fixes

### DIFF
--- a/payload-cms/src/migrations/20260304_000000_add_lesson_bookmarks_rel_columns.ts
+++ b/payload-cms/src/migrations/20260304_000000_add_lesson_bookmarks_rel_columns.ts
@@ -1,0 +1,47 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE IF EXISTS "payload_locked_documents_rels"
+      ADD COLUMN IF NOT EXISTS "lesson_bookmarks_id" integer;
+
+    ALTER TABLE IF EXISTS "payload_preferences_rels"
+      ADD COLUMN IF NOT EXISTS "lesson_bookmarks_id" integer;
+
+    DO $$ BEGIN
+      ALTER TABLE "payload_locked_documents_rels"
+        ADD CONSTRAINT "payload_locked_documents_rels_lesson_bookmarks_fk"
+        FOREIGN KEY ("lesson_bookmarks_id") REFERENCES "public"."lesson_bookmarks"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+
+    DO $$ BEGIN
+      ALTER TABLE "payload_preferences_rels"
+        ADD CONSTRAINT "payload_preferences_rels_lesson_bookmarks_fk"
+        FOREIGN KEY ("lesson_bookmarks_id") REFERENCES "public"."lesson_bookmarks"("id") ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL;
+    END $$;
+
+    CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_lesson_bookmarks_id_idx"
+      ON "payload_locked_documents_rels" USING btree ("lesson_bookmarks_id");
+    CREATE INDEX IF NOT EXISTS "payload_preferences_rels_lesson_bookmarks_id_idx"
+      ON "payload_preferences_rels" USING btree ("lesson_bookmarks_id");
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE IF EXISTS "payload_locked_documents_rels"
+      DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_lesson_bookmarks_fk";
+    ALTER TABLE IF EXISTS "payload_preferences_rels"
+      DROP CONSTRAINT IF EXISTS "payload_preferences_rels_lesson_bookmarks_fk";
+
+    DROP INDEX IF EXISTS "payload_locked_documents_rels_lesson_bookmarks_id_idx";
+    DROP INDEX IF EXISTS "payload_preferences_rels_lesson_bookmarks_id_idx";
+
+    ALTER TABLE IF EXISTS "payload_locked_documents_rels"
+      DROP COLUMN IF EXISTS "lesson_bookmarks_id";
+    ALTER TABLE IF EXISTS "payload_preferences_rels"
+      DROP COLUMN IF EXISTS "lesson_bookmarks_id";
+  `)
+}

--- a/payload-cms/src/migrations/index.ts
+++ b/payload-cms/src/migrations/index.ts
@@ -5,6 +5,7 @@ import * as migration_20251228_190000_lesson_feedback_nav_order from './20251228
 import * as migration_20251229_183000_user_names_theme from './20251229_183000_user_names_theme';
 import * as migration_20260105_120000_add_professor_role from './20260105_120000_add_professor_role';
 import * as migration_20260212_161835_add_classrooms_and_memberships from './20260212_161835_add_classrooms_and_memberships';
+import * as migration_20260304_000000_add_lesson_bookmarks_rel_columns from './20260304_000000_add_lesson_bookmarks_rel_columns';
 
 export const migrations = [
   {
@@ -41,5 +42,10 @@ export const migrations = [
     up: migration_20260212_161835_add_classrooms_and_memberships.up,
     down: migration_20260212_161835_add_classrooms_and_memberships.down,
     name: '20260212_161835_add_classrooms_and_memberships',
+  },
+  {
+    up: migration_20260304_000000_add_lesson_bookmarks_rel_columns.up,
+    down: migration_20260304_000000_add_lesson_bookmarks_rel_columns.down,
+    name: '20260304_000000_add_lesson_bookmarks_rel_columns',
   },
 ];

--- a/payload-cms/src/utils/analyticsSummary.ts
+++ b/payload-cms/src/utils/analyticsSummary.ts
@@ -95,7 +95,7 @@ const findAllDocs = async (
       sort: 'id',
     })
 
-    docs.push(...(result.docs as Record<string, unknown>[]))
+    docs.push(...(result.docs as unknown as Record<string, unknown>[]))
     hasNextPage = Boolean(result.hasNextPage)
     page += 1
   }

--- a/payload-cms/src/views/StaffDashboardView.tsx
+++ b/payload-cms/src/views/StaffDashboardView.tsx
@@ -172,6 +172,7 @@ const StaffDashboardContent = ({
   user,
   stats,
   contentHealth,
+  reporting,
 }: {
   user?: AdminViewServerProps['initPageResult']['req']['user']
   stats: {


### PR DESCRIPTION
### Motivation
- Add nullable foreign-key relation columns for `lesson_bookmarks` on existing rel tables so bookmarks can be associated from locked documents and preferences.
- Expose reporting data in the staff dashboard component and fix a typing inconsistency when aggregating documents for analytics.

### Description
- Added a new migration `20260304_000000_add_lesson_bookmarks_rel_columns.ts` that adds `lesson_bookmarks_id` integer columns to `payload_locked_documents_rels` and `payload_preferences_rels`, creates FK constraints referencing `lesson_bookmarks(id)` with `ON DELETE cascade`, and adds btree indexes; the `down` migration drops the constraints, indexes, and columns.
- Registered the new migration in `migrations/index.ts` so it will run as part of the migration list.
- Adjusted `findAllDocs` in `payload-cms/src/utils/analyticsSummary.ts` to cast `result.docs` as `unknown as Record<string, unknown>[]` to satisfy TypeScript typing when spreading into the `docs` array.
- Added a `reporting` prop to the `StaffDashboardContent` props interface in `payload-cms/src/views/StaffDashboardView.tsx` to accept reporting summaries for the staff dashboard.

### Testing
- No new automated tests were added for this change; existing automated tests were not modified.
- Verified local type-check/build to ensure the TypeScript changes compile without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e1dd71f0832d929f58199005edc8)