### PR TITLE
Add weekly goals, streaks, milestone badges, and next-best-action cards to Learning personalization

### DIFF
--- a/web/src/components/learning/LearningPersonalization.tsx
+++ b/web/src/components/learning/LearningPersonalization.tsx
@@ -2,7 +2,14 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { Bookmark, BookmarkCheck, PlayCircle } from "lucide-react";
+import {
+  Award,
+  Bookmark,
+  BookmarkCheck,
+  Flame,
+  PlayCircle,
+  Target,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getPayloadBaseUrl } from "@/lib/payloadSdk/payloadUrl";
 
@@ -69,6 +76,17 @@ type SavedLessonItem = {
   savedAt?: string;
 };
 
+type NextBestAction = {
+  key: string;
+  label: string;
+  title: string;
+  description: string;
+  href: string;
+  cta: string;
+};
+
+const WEEKLY_GOAL_TARGET = 5;
+
 const getRelationId = (value: RelationValue): string | null => {
   if (typeof value === "string" || typeof value === "number") {
     return String(value);
@@ -111,6 +129,21 @@ const formatDate = (value?: string) => {
     day: "numeric",
     year: "numeric",
   });
+};
+
+const toLocalDayKey = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  const localDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  return localDate.toISOString().slice(0, 10);
+};
+
+const getWeekStart = (date: Date) => {
+  const start = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const day = start.getDay();
+  start.setDate(start.getDate() - day);
+  start.setHours(0, 0, 0, 0);
+  return start;
 };
 
 export function LearningPersonalization({ lessonIndex }: Props) {
@@ -227,6 +260,69 @@ export function LearningPersonalization({ lessonIndex }: Props) {
     });
     return ids;
   }, [progressDocs]);
+
+  const completedCount = completedLessonIds.size;
+
+  const weeklyGoal = useMemo(() => {
+    const weekStart = getWeekStart(new Date());
+    const seen = new Set<string>();
+    progressDocs.forEach((doc) => {
+      if (!doc.completed) return;
+      const lessonId = getRelationId(doc.lesson);
+      const stamp = doc.completedAt ?? doc.updatedAt;
+      if (!lessonId || !stamp) return;
+      const completionDate = new Date(stamp);
+      if (Number.isNaN(completionDate.getTime())) return;
+      if (completionDate >= weekStart) {
+        seen.add(lessonId);
+      }
+    });
+
+    const completedThisWeek = seen.size;
+    const progress = Math.min(completedThisWeek / WEEKLY_GOAL_TARGET, 1);
+    return {
+      completedThisWeek,
+      remaining: Math.max(WEEKLY_GOAL_TARGET - completedThisWeek, 0),
+      progress,
+      reached: completedThisWeek >= WEEKLY_GOAL_TARGET,
+    };
+  }, [progressDocs]);
+
+  const streak = useMemo(() => {
+    const daySet = new Set<string>();
+    progressDocs.forEach((doc) => {
+      const stamp = doc.updatedAt ?? doc.completedAt;
+      if (!stamp) return;
+      const key = toLocalDayKey(stamp);
+      if (key) daySet.add(key);
+    });
+    if (!daySet.size) return { count: 0, activeToday: false };
+
+    const today = new Date();
+    const todayKey = toLocalDayKey(today.toISOString());
+    let cursor = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    let count = 0;
+
+    while (true) {
+      const key = toLocalDayKey(cursor.toISOString());
+      if (!key || !daySet.has(key)) break;
+      count += 1;
+      cursor.setDate(cursor.getDate() - 1);
+    }
+
+    return {
+      count,
+      activeToday: !!todayKey && daySet.has(todayKey),
+    };
+  }, [progressDocs]);
+
+  const milestoneBadges = useMemo(() => {
+    const tiers = [1, 3, 5, 10, 20];
+    return tiers.map((tier) => ({
+      tier,
+      earned: completedCount >= tier,
+    }));
+  }, [completedCount]);
 
   const resumeSelection = useMemo<ResumeSelection | null>(() => {
     if (!orderedLessons.length) return null;
@@ -353,101 +449,231 @@ export function LearningPersonalization({ lessonIndex }: Props) {
     return items.slice(0, 8);
   }, [bookmarkDocs, lessonsById]);
 
-  return (
-    <section className="mt-6 grid gap-4 lg:grid-cols-2">
-      <article className="rounded-xl border border-border/60 bg-muted/10 p-5 shadow-sm">
-        <div className="mb-4 flex items-center gap-2">
-          <PlayCircle className="h-4 w-4 text-muted-foreground" />
-          <h2 className="text-base font-semibold">Continue Learning</h2>
-        </div>
+  const nextBestActions = useMemo<NextBestAction[]>(() => {
+    if (!resumeSelection) return [];
 
-        {!resolvedUser || loadingData ? (
-          <p className="text-sm text-muted-foreground">
-            Loading your progress...
-          </p>
-        ) : !user ? (
-          <p className="text-sm text-muted-foreground">
-            <Link href="/login" className="font-semibold text-foreground">
-              Sign in
-            </Link>{" "}
-            to resume where you left off.
-          </p>
-        ) : resumeSelection ? (
-          <div className="space-y-3">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Next up
-              </p>
-              <p className="text-lg font-semibold text-foreground">
-                {resumeSelection.lesson.title}
-              </p>
+    const actions: NextBestAction[] = [
+      {
+        key: "resume",
+        label: "Continue",
+        title: resumeSelection.lesson.title,
+        description: resumeSelection.hint,
+        href: `/classes/${resumeSelection.lesson.classSlug}/lessons/${resumeSelection.lesson.slug}`,
+        cta: "Open lesson",
+      },
+    ];
+
+    if (!streak.activeToday) {
+      actions.push({
+        key: "streak",
+        label: "Streak",
+        title: streak.count
+          ? `Keep your ${streak.count}-day streak alive`
+          : "Start a learning streak today",
+        description:
+          "A short lesson today helps build momentum and stronger retention.",
+        href: `/classes/${resumeSelection.lesson.classSlug}/lessons/${resumeSelection.lesson.slug}`,
+        cta: "Do a quick lesson",
+      });
+    }
+
+    if (!weeklyGoal.reached) {
+      actions.push({
+        key: "goal",
+        label: "Weekly goal",
+        title: `${weeklyGoal.remaining} lesson${weeklyGoal.remaining === 1 ? "" : "s"} left this week`,
+        description: "Stay on pace by completing one more lesson now.",
+        href: `/classes/${resumeSelection.lesson.classSlug}/lessons/${resumeSelection.lesson.slug}`,
+        cta: "Make progress",
+      });
+    }
+
+    if (savedLessons[0]) {
+      actions.push({
+        key: "saved",
+        label: "Saved",
+        title: `Revisit: ${savedLessons[0].title}`,
+        description: "You bookmarked this topic for a reason—pick it back up.",
+        href: savedLessons[0].href,
+        cta: "Open saved lesson",
+      });
+    }
+
+    return actions.slice(0, 3);
+  }, [resumeSelection, savedLessons, streak, weeklyGoal]);
+
+  return (
+    <section className="mt-6 space-y-4">
+      <div className="grid gap-4 md:grid-cols-3">
+        <article className="rounded-xl border border-border/60 bg-muted/10 p-5 shadow-sm">
+          <div className="mb-3 flex items-center gap-2">
+            <Target className="h-4 w-4 text-muted-foreground" />
+            <h2 className="text-sm font-semibold">Weekly Goal</h2>
+          </div>
+          {!resolvedUser || loadingData ? (
+            <p className="text-sm text-muted-foreground">Loading goal...</p>
+          ) : !user ? (
+            <p className="text-sm text-muted-foreground">Sign in to track weekly goals.</p>
+          ) : (
+            <div className="space-y-2">
               <p className="text-sm text-muted-foreground">
-                {resumeSelection.lesson.classTitle} ·{" "}
-                {resumeSelection.lesson.chapterTitle}
+                {weeklyGoal.completedThisWeek} / {WEEKLY_GOAL_TARGET} lessons completed this week
+              </p>
+              <div className="h-2 rounded-full bg-muted">
+                <div
+                  className="h-2 rounded-full bg-primary transition-all"
+                  style={{ width: `${weeklyGoal.progress * 100}%` }}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {weeklyGoal.reached
+                  ? "Goal reached. Amazing consistency."
+                  : `${weeklyGoal.remaining} lesson${weeklyGoal.remaining === 1 ? "" : "s"} to go.`}
               </p>
             </div>
-            <p className="text-sm text-muted-foreground">
-              {resumeSelection.hint}
-            </p>
-            <Button asChild className="rounded-full">
-              <Link
-                href={`/classes/${resumeSelection.lesson.classSlug}/lessons/${resumeSelection.lesson.slug}`}
-              >
-                Resume lesson
-              </Link>
-            </Button>
-          </div>
-        ) : (
-          <p className="text-sm text-muted-foreground">
-            No lessons available to resume yet.
-          </p>
-        )}
-      </article>
-
-      <article className="rounded-xl border border-border/60 bg-muted/10 p-5 shadow-sm">
-        <div className="mb-4 flex items-center gap-2">
-          {savedLessons.length > 0 ? (
-            <BookmarkCheck className="h-4 w-4 text-muted-foreground" />
-          ) : (
-            <Bookmark className="h-4 w-4 text-muted-foreground" />
           )}
-          <h2 className="text-base font-semibold">Saved Lessons</h2>
-        </div>
+        </article>
 
-        {!resolvedUser || loadingData ? (
-          <p className="text-sm text-muted-foreground">
-            Loading your saved lessons...
-          </p>
-        ) : !user ? (
-          <p className="text-sm text-muted-foreground">
-            Sign in to access your saved lessons.
-          </p>
-        ) : savedLessons.length ? (
-          <ul className="space-y-3">
-            {savedLessons.map((item) => {
-              const savedAtLabel = formatDate(item.savedAt);
-              return (
-                <li key={item.key}>
-                  <Link
-                    href={item.href}
-                    className="block rounded-lg border border-border/60 bg-background/30 px-3 py-2 transition hover:border-border/90 hover:bg-background/50"
-                  >
-                    <p className="font-medium text-foreground">{item.title}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {item.subtitle}
-                      {savedAtLabel ? ` · Saved ${savedAtLabel}` : ""}
-                    </p>
-                  </Link>
+        <article className="rounded-xl border border-border/60 bg-muted/10 p-5 shadow-sm">
+          <div className="mb-3 flex items-center gap-2">
+            <Flame className="h-4 w-4 text-muted-foreground" />
+            <h2 className="text-sm font-semibold">Progress Streak</h2>
+          </div>
+          {!resolvedUser || loadingData ? (
+            <p className="text-sm text-muted-foreground">Loading streak...</p>
+          ) : !user ? (
+            <p className="text-sm text-muted-foreground">Sign in to maintain your streak.</p>
+          ) : (
+            <div>
+              <p className="text-2xl font-bold text-foreground">{streak.count} day{streak.count === 1 ? "" : "s"}</p>
+              <p className="text-sm text-muted-foreground">
+                {streak.activeToday
+                  ? "You’re active today—streak protected."
+                  : "Complete a lesson today to extend your streak."}
+              </p>
+            </div>
+          )}
+        </article>
+
+        <article className="rounded-xl border border-border/60 bg-muted/10 p-5 shadow-sm">
+          <div className="mb-3 flex items-center gap-2">
+            <Award className="h-4 w-4 text-muted-foreground" />
+            <h2 className="text-sm font-semibold">Milestone Badges</h2>
+          </div>
+          {!resolvedUser || loadingData ? (
+            <p className="text-sm text-muted-foreground">Loading badges...</p>
+          ) : !user ? (
+            <p className="text-sm text-muted-foreground">Sign in to unlock badges.</p>
+          ) : (
+            <ul className="flex flex-wrap gap-2">
+              {milestoneBadges.map((badge) => (
+                <li
+                  key={badge.tier}
+                  className={`rounded-full border px-3 py-1 text-xs font-semibold ${
+                    badge.earned
+                      ? "border-primary/40 bg-primary/15 text-foreground"
+                      : "border-border/60 bg-background/30 text-muted-foreground"
+                  }`}
+                >
+                  {badge.earned ? "✓ " : ""}
+                  {badge.tier} lesson{badge.tier === 1 ? "" : "s"}
                 </li>
-              );
-            })}
-          </ul>
-        ) : (
-          <p className="text-sm text-muted-foreground">
-            No saved lessons yet. Use the save button on any lesson page.
-          </p>
-        )}
-      </article>
+              ))}
+            </ul>
+          )}
+        </article>
+      </div>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <article className="rounded-xl border border-border/60 bg-muted/10 p-5 shadow-sm">
+          <div className="mb-4 flex items-center gap-2">
+            <PlayCircle className="h-4 w-4 text-muted-foreground" />
+            <h2 className="text-base font-semibold">Next Best Actions</h2>
+          </div>
+
+          {!resolvedUser || loadingData ? (
+            <p className="text-sm text-muted-foreground">
+              Loading your progress...
+            </p>
+          ) : !user ? (
+            <p className="text-sm text-muted-foreground">
+              <Link href="/login" className="font-semibold text-foreground">
+                Sign in
+              </Link>{" "}
+              to resume where you left off.
+            </p>
+          ) : nextBestActions.length ? (
+            <ul className="space-y-3">
+              {nextBestActions.map((action) => (
+                <li
+                  key={action.key}
+                  className="rounded-lg border border-border/60 bg-background/30 p-3"
+                >
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {action.label}
+                  </p>
+                  <p className="font-semibold text-foreground">{action.title}</p>
+                  <p className="mb-2 text-sm text-muted-foreground">
+                    {action.description}
+                  </p>
+                  <Button asChild size="sm" className="rounded-full">
+                    <Link href={action.href}>{action.cta}</Link>
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No lessons available to resume yet.
+            </p>
+          )}
+        </article>
+
+        <article className="rounded-xl border border-border/60 bg-muted/10 p-5 shadow-sm">
+          <div className="mb-4 flex items-center gap-2">
+            {savedLessons.length > 0 ? (
+              <BookmarkCheck className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <Bookmark className="h-4 w-4 text-muted-foreground" />
+            )}
+            <h2 className="text-base font-semibold">Saved Lessons</h2>
+          </div>
+
+          {!resolvedUser || loadingData ? (
+            <p className="text-sm text-muted-foreground">
+              Loading your saved lessons...
+            </p>
+          ) : !user ? (
+            <p className="text-sm text-muted-foreground">
+              Sign in to access your saved lessons.
+            </p>
+          ) : savedLessons.length ? (
+            <ul className="space-y-3">
+              {savedLessons.map((item) => {
+                const savedAtLabel = formatDate(item.savedAt);
+                return (
+                  <li key={item.key}>
+                    <Link
+                      href={item.href}
+                      className="block rounded-lg border border-border/60 bg-background/30 px-3 py-2 transition hover:border-border/90 hover:bg-background/50"
+                    >
+                      <p className="font-medium text-foreground">{item.title}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {item.subtitle}
+                        {savedAtLabel ? ` · Saved ${savedAtLabel}` : ""}
+                      </p>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No saved lessons yet. Use the save button on any lesson page.
+            </p>
+          )}
+        </article>
+      </section>
     </section>
   );
 }


### PR DESCRIPTION
### Motivation
- Surface lightweight motivation features in the student learning experience (weekly goals, streaks, badges, and prioritized actions) using existing progress and bookmark data to increase completion without backend schema changes.
- Keep the implementation frontend-only so features can be enabled immediately and derived from the `lesson-progress` and `lesson-bookmarks` collections.

### Description
- Extended `src/components/learning/LearningPersonalization.tsx` to compute and surface motivation signals including a weekly goal (constant `WEEKLY_GOAL_TARGET`), a consecutive-day progress streak, milestone badge states, and a prioritized `NextBestAction` list derived from existing `progressDocs` and `bookmarkDocs`.
- Added helper utilities `toLocalDayKey` and `getWeekStart`, new types (`NextBestAction`), and computed values (`weeklyGoal`, `streak`, `milestoneBadges`, `completedCount`, `nextBestActions`) used by the UI.
- Updated the UI to add three new cards (`Weekly Goal`, `Progress Streak`, `Milestone Badges`) and replaced the old single "Continue Learning" panel with a `Next Best Actions` list while keeping the `Saved Lessons` panel.
- No backend or API changes were required; all logic is client-side and reuses existing API endpoints (`/api/lesson-progress`, `/api/lesson-bookmarks`, `/api/accounts/me`).

### Testing
- Ran `cd web && pnpm install`, which failed due to private registry authentication (`ERR_PNPM_FETCH_403`), so dependencies were not installed in this environment and end-to-end runtime tests could not be performed.
- Ran `cd web && pnpm lint`, which failed because project dependencies (including `next` and eslint peer deps) were not available after the install failure, so static lint checks could not complete.
- Ran `cd web && pnpm dev`, which failed because `next` is not available without a successful dependency install, so the dev server could not be started.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7fbff9490832d8df159924cf3838d)