### PR TITLE
Fix email confirmation expiry validation for malformed timestamps

### DIFF
--- a/payload-cms/src/endpoints/emailConfirmation.ts
+++ b/payload-cms/src/endpoints/emailConfirmation.ts
@@ -105,10 +105,13 @@ export const confirmEmailHandler = async (req: PayloadRequest) => {
     return jsonResponse({ message: 'Token is invalid or expired.' }, 400)
   }
 
-  const expiresAt = account.emailVerificationExpiresAt
+  const expiresAtMs = account.emailVerificationExpiresAt
     ? new Date(account.emailVerificationExpiresAt).getTime()
-    : 0
-  if (expiresAt && Date.now() > expiresAt) {
+    : null
+  const isExpired =
+    expiresAtMs == null || Number.isNaN(expiresAtMs) || Date.now() > expiresAtMs
+
+  if (isExpired) {
     await req.payload.update({
       collection: 'accounts',
       id: account.id,


### PR DESCRIPTION
### Motivation
- A malformed or missing `emailVerificationExpiresAt` could produce `NaN` and cause `Date.now() > NaN` to be false, allowing an expired or invalid confirmation token to be accepted.

### Description
- Treat missing or invalid `emailVerificationExpiresAt` values as expired by computing `expiresAtMs` and an `isExpired` check, and continue to clear token fields and return a 400 response when the token is expired or invalid.

### Testing
- Ran unit node tests with `cd payload-cms && pnpm run test:unit:node`, which passed; attempting `cd payload-cms && pnpm test -- --runInBand` failed to run in this environment due to missing dev dependencies, and `cd web && pnpm install` failed due to a network/proxy restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa65e14ab0832d8f13feb64f40ec85)