### PR TITLE
Add auth email templates, email preview endpoint, and fix email confirmation expiry

### DIFF
--- a/payload-cms/src/collections/Accounts.ts
+++ b/payload-cms/src/collections/Accounts.ts
@@ -1,3 +1,4 @@
+import { buildAuthEmail, buildResetPasswordUrl } from '../utils/authEmails'
 import type { CollectionConfig } from 'payload'
 
 const cookieSecure = (() => {
@@ -27,6 +28,29 @@ export const Accounts: CollectionConfig = {
       sameSite: cookieSameSite,
       domain: cookieDomain,
     },
+    forgotPassword: {
+      generateEmailSubject: () => 'Reset your NSF CURE account password',
+      generateEmailHTML: ({ token }: { token: string }) => {
+        const resetUrl = buildResetPasswordUrl(token)
+        return buildAuthEmail({
+          heading: 'Reset your NSF CURE account password',
+          intro: 'A password reset was requested for your account.',
+          actionLabel: 'Reset password',
+          actionUrl: resetUrl,
+          securityNote: 'If you did not request a password reset, you can safely ignore this email.',
+        }).html
+      },
+      generateEmailText: ({ token }: { token: string }) => {
+        const resetUrl = buildResetPasswordUrl(token)
+        return buildAuthEmail({
+          heading: 'Reset your NSF CURE account password',
+          intro: 'A password reset was requested for your account.',
+          actionLabel: 'Reset password',
+          actionUrl: resetUrl,
+          securityNote: 'If you did not request a password reset, you can safely ignore this email.',
+        }).text
+      },
+    },
   },
   admin: {
     useAsTitle: 'email',
@@ -53,15 +77,18 @@ export const Accounts: CollectionConfig = {
           overrideAccess: true,
         })
 
+        const message = buildAuthEmail({
+          heading: 'Confirm your NSF CURE account email',
+          intro: 'Please confirm your email address to activate your account.',
+          actionLabel: 'Confirm email address',
+          actionUrl: confirmUrl,
+          securityNote: 'If you did not create this account, no further action is needed.',
+        })
+
         await req.payload.sendEmail({
           to: doc.email,
           subject: 'Confirm your NSF CURE account email',
-          text: `Confirm your email address by visiting ${confirmUrl}. This link expires in 24 hours.`,
-          html: `
-            <p>Confirm your email address by clicking the link below:</p>
-            <p><a href="${confirmUrl}">Confirm email address</a></p>
-            <p>This link expires in 24 hours.</p>
-          `,
+          ...message,
         })
 
         return doc

--- a/payload-cms/src/endpoints/emailConfirmation.ts
+++ b/payload-cms/src/endpoints/emailConfirmation.ts
@@ -1,5 +1,6 @@
 import type { PayloadRequest } from 'payload'
 
+import { buildAuthEmail } from '../utils/authEmails'
 import { buildEmailConfirmation, hashEmailToken } from '../utils/emailConfirmation'
 
 const jsonResponse = (data: unknown, status = 200) =>
@@ -36,15 +37,18 @@ export const requestEmailConfirmationHandler = async (req: PayloadRequest) => {
     overrideAccess: true,
   })
 
+  const message = buildAuthEmail({
+    heading: 'Confirm your NSF CURE account email',
+    intro: 'Please confirm your email address to activate your account.',
+    actionLabel: 'Confirm email address',
+    actionUrl: confirmUrl,
+    securityNote: 'If you did not create this account, no further action is needed.',
+  })
+
   await req.payload.sendEmail({
     to: email,
     subject: 'Confirm your NSF CURE account email',
-    text: `Confirm your email address by visiting ${confirmUrl}. This link expires in 24 hours.`,
-    html: `
-      <p>Confirm your email address by clicking the link below:</p>
-      <p><a href="${confirmUrl}">Confirm email address</a></p>
-      <p>This link expires in 24 hours.</p>
-    `,
+    ...message,
   })
 
   return jsonResponse({ message: 'Confirmation link sent.' }, 200)
@@ -105,10 +109,13 @@ export const confirmEmailHandler = async (req: PayloadRequest) => {
     return jsonResponse({ message: 'Token is invalid or expired.' }, 400)
   }
 
-  const expiresAt = account.emailVerificationExpiresAt
+  const expiresAtMs = account.emailVerificationExpiresAt
     ? new Date(account.emailVerificationExpiresAt).getTime()
-    : 0
-  if (expiresAt && Date.now() > expiresAt) {
+    : null
+  const isExpired =
+    expiresAtMs == null || Number.isNaN(expiresAtMs) || Date.now() > expiresAtMs
+
+  if (isExpired) {
     await req.payload.update({
       collection: 'accounts',
       id: account.id,

--- a/payload-cms/src/endpoints/emailPreview.ts
+++ b/payload-cms/src/endpoints/emailPreview.ts
@@ -1,0 +1,70 @@
+import type { PayloadRequest } from 'payload'
+
+import { buildAuthEmail, buildResetPasswordUrl } from '../utils/authEmails'
+
+const jsonResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const resolveType = (value: unknown) =>
+  value === 'reset-password' || value === 'confirm-email' ? value : 'confirm-email'
+
+const resolveToken = (value: unknown) =>
+  typeof value === 'string' && value.trim() ? value.trim() : 'EXAMPLE_TOKEN_PREVIEW'
+
+export const emailPreviewHandler = async (req: PayloadRequest) => {
+  const requestMeta = req as unknown as {
+    query?: Record<string, unknown>
+    json?: () => Promise<unknown>
+  }
+
+  const query = requestMeta.query ?? {}
+
+  let body: unknown = req.body
+  if (!body && typeof requestMeta.json === 'function') {
+    try {
+      body = await requestMeta.json()
+    } catch {
+      body = undefined
+    }
+  }
+
+  const bodyData = (body ?? {}) as Record<string, unknown>
+  const type = resolveType(bodyData.type ?? query.type)
+  const token = resolveToken(bodyData.token ?? query.token)
+
+  const content =
+    type === 'reset-password'
+      ? {
+          subject: '[Preview] Reset your NSF CURE account password',
+          ...buildAuthEmail({
+            heading: 'Reset your NSF CURE account password',
+            intro: 'A password reset was requested for your account.',
+            actionLabel: 'Reset password',
+            actionUrl: buildResetPasswordUrl(token),
+            securityNote: 'If you did not request a password reset, you can safely ignore this email.',
+          }),
+        }
+      : {
+          subject: '[Preview] Confirm your NSF CURE account email',
+          ...buildAuthEmail({
+            heading: 'Confirm your NSF CURE account email',
+            intro: 'Please confirm your email address to activate your account.',
+            actionLabel: 'Confirm email address',
+            actionUrl: `${process.env.WEB_PUBLIC_URL ?? process.env.WEB_PREVIEW_URL ?? 'http://localhost:3001'}/confirm-email?token=${encodeURIComponent(token)}`,
+            securityNote: 'If you did not create this account, no further action is needed.',
+          }),
+        }
+
+  req.payload.logger.info('[email-preview] generated email preview payload')
+  req.payload.logger.info(content.text)
+  req.payload.logger.info(content.html)
+
+  return jsonResponse({
+    mode: 'preview-only',
+    type,
+    ...content,
+  })
+}

--- a/payload-cms/src/payload.config.ts
+++ b/payload-cms/src/payload.config.ts
@@ -41,6 +41,7 @@ import { confirmEmailHandler, requestEmailConfirmationHandler } from './endpoint
 import { logoutAllSessionsHandler } from './endpoints/logoutAll'
 import { accountsMeHandler } from './endpoints/accountsMe'
 import { reportingSummaryHandler } from './endpoints/reportingSummary'
+import { emailPreviewHandler } from './endpoints/emailPreview'
 // Uses the generated import map entry for the dashboard view component
 const StaffDashboardView: PayloadComponent = {
   path: '@/views/StaffDashboardView#default',
@@ -240,6 +241,16 @@ export default buildConfig({
       path: '/accounts/logout-all',
       method: 'post',
       handler: logoutAllSessionsHandler,
+    },
+    {
+      path: '/accounts/email-preview',
+      method: 'post',
+      handler: emailPreviewHandler,
+    },
+    {
+      path: '/accounts/email-preview',
+      method: 'get',
+      handler: emailPreviewHandler,
     },
     {
       path: '/analytics/reporting-summary',

--- a/payload-cms/src/utils/authEmails.ts
+++ b/payload-cms/src/utils/authEmails.ts
@@ -1,0 +1,48 @@
+const getWebBaseUrl = () =>
+  process.env.WEB_PUBLIC_URL ?? process.env.WEB_PREVIEW_URL ?? 'http://localhost:3001'
+
+const getSupportEmail = () => process.env.SUPPORT_EMAIL ?? 'sbp-support@cpp.edu'
+
+const buildSupportLine = () =>
+  `If you need help, contact support at ${getSupportEmail()}.`
+
+export const buildResetPasswordUrl = (token: string) =>
+  `${getWebBaseUrl()}/reset-password?token=${encodeURIComponent(token)}`
+
+export const buildAuthEmail = ({
+  heading,
+  actionLabel,
+  actionUrl,
+  expiresIn = '24 hours',
+  intro,
+  securityNote,
+}: {
+  heading: string
+  actionLabel: string
+  actionUrl: string
+  expiresIn?: string
+  intro: string
+  securityNote?: string
+}) => {
+  const securityText = securityNote ? `${securityNote}\n\n` : ''
+  const supportLine = buildSupportLine()
+
+  const text = `${intro}\n\n${actionLabel}: ${actionUrl}\n\nThis link expires in ${expiresIn}.\n\n${securityText}${supportLine}`
+
+  const html = `
+    <div style="font-family:Arial,sans-serif;line-height:1.6;color:#111827">
+      <h2 style="margin-bottom:8px">${heading}</h2>
+      <p>${intro}</p>
+      <p>
+        <a href="${actionUrl}" style="display:inline-block;background:#111827;color:#ffffff;padding:10px 16px;border-radius:6px;text-decoration:none">${actionLabel}</a>
+      </p>
+      <p style="font-size:13px;color:#4b5563">If the button does not work, copy and paste this URL into your browser:</p>
+      <p style="font-size:13px;word-break:break-all">${actionUrl}</p>
+      <p style="font-size:13px;color:#4b5563">This link expires in ${expiresIn}.</p>
+      ${securityNote ? `<p style="font-size:13px;color:#4b5563">${securityNote}</p>` : ''}
+      <p style="font-size:13px;color:#4b5563">${supportLine}</p>
+    </div>
+  `
+
+  return { text, html }
+}

--- a/payload-cms/tests/unit-node/utils.test.mjs
+++ b/payload-cms/tests/unit-node/utils.test.mjs
@@ -5,6 +5,7 @@ import { ensureUniqueSlug, slugify } from '../../src/utils/slug.ts'
 import { generateUniqueJoinCode } from '../../src/utils/joinCode.ts'
 import { getReportingSummary, reportRowsToCsv } from '../../src/utils/analyticsSummary.ts'
 import { buildEmailConfirmation, hashEmailToken } from '../../src/utils/emailConfirmation.ts'
+import { buildAuthEmail, buildResetPasswordUrl } from '../../src/utils/authEmails.ts'
 
 describe('slug utilities', () => {
   it('slugify normalizes text and strips symbols', () => {
@@ -201,6 +202,41 @@ describe('analytics summary utilities', () => {
   })
 })
 
+
+
+describe('auth email template utilities', () => {
+  it('buildResetPasswordUrl URL-encodes token values', () => {
+    process.env.WEB_PUBLIC_URL = 'https://app.example.com'
+    const url = buildResetPasswordUrl('a+b/c?d=e')
+    assert.equal(url, 'https://app.example.com/reset-password?token=a%2Bb%2Fc%3Fd%3De')
+    delete process.env.WEB_PUBLIC_URL
+  })
+
+  it('buildAuthEmail returns matching text and html content', () => {
+    process.env.SUPPORT_EMAIL = 'help@example.com'
+
+    const message = buildAuthEmail({
+      heading: 'Confirm your account',
+      intro: 'Please confirm your account.',
+      actionLabel: 'Confirm account',
+      actionUrl: 'https://app.example.com/confirm?token=123',
+      expiresIn: '48 hours',
+      securityNote: 'If this was not you, ignore this email.',
+    })
+
+    assert.match(message.text, /Confirm account: https:\/\/app\.example\.com\/confirm\?token=123/)
+    assert.match(message.text, /expires in 48 hours\./)
+    assert.match(message.text, /If this was not you, ignore this email\./)
+    assert.match(message.text, /contact support at help@example\.com\./)
+    assert.match(message.html, /<h2[^>]*>Confirm your account<\/h2>/)
+    assert.match(message.html, /href="https:\/\/app\.example\.com\/confirm\?token=123"/)
+    assert.match(message.html, /This link expires in 48 hours\./)
+    assert.match(message.html, /If this was not you, ignore this email\./)
+    assert.match(message.html, /contact support at help@example\.com\./)
+
+    delete process.env.SUPPORT_EMAIL
+  })
+})
 describe('email confirmation utilities', () => {
   const prevPublic = process.env.WEB_PUBLIC_URL
   const prevPreview = process.env.WEB_PREVIEW_URL


### PR DESCRIPTION
### Motivation

- Provide consistent HTML/text email templates for account actions (confirm email, reset password) to improve UX and maintainability.
- Add a preview endpoint to allow local/preview rendering of auth emails without sending real messages for easier development and QA.
- Fix token expiry detection in the email confirmation flow to correctly treat missing/invalid expiry values as expired.

### Description

- Introduces `payload-cms/src/utils/authEmails.ts` with `buildAuthEmail` and `buildResetPasswordUrl` to generate unified text/html email content and reset links. 
- Updates the `accounts` collection in `payload-cms/src/collections/Accounts.ts` to use the new templates for the `forgotPassword` emails and to build confirmation messages in the `afterChange` hook. 
- Changes `payload-cms/src/endpoints/emailConfirmation.ts` to use the new template builder for request emails and adjusts expiry handling by computing `expiresAtMs` and an `isExpired` flag. 
- Adds a new preview endpoint `payload-cms/src/endpoints/emailPreview.ts` and registers `GET`/`POST` routes in `payload-cms/src/payload.config.ts` at `/accounts/email-preview` to return preview payloads for `reset-password` and `confirm-email`. 
- Adds unit tests in `payload-cms/tests/unit-node/utils.test.mjs` for `buildResetPasswordUrl` and `buildAuthEmail`, and imports the new utilities into tests.

### Testing

- Ran the unit test suite with `npm test`, which included the new tests for `buildResetPasswordUrl` and `buildAuthEmail`, and all tests passed. 
- Existing email confirmation tests were exercised and the updated expiry logic behaves as expected in the test scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa65e14ab0832d8f13feb64f40ec85)