### PR TITLE
Add unlisted student arrival map

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -125,7 +125,7 @@ const nextConfig: NextConfig = {
       "font-src 'self' data: https://fonts.gstatic.com",
       `img-src 'self' data: blob: https://i.ytimg.com${cmsHostFromEnv ? ` ${cmsHostFromEnv}` : ""}`,
       `connect-src 'self'${cmsHostFromEnv ? ` ${cmsHostFromEnv}` : ""}`,
-      "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
+      "frame-src 'self' https://www.google.com https://maps.google.com https://www.youtube.com https://www.youtube-nocookie.com",
       `frame-ancestors ${frameAncestors}`,
       "form-action 'self'",
       "base-uri 'self'",

--- a/web/src/app/arrival-map/ArrivalMapClient.tsx
+++ b/web/src/app/arrival-map/ArrivalMapClient.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import Link from "next/link";
+import {
+  Accessibility,
+  ArrowRight,
+  CarFront,
+  Check,
+  ExternalLink,
+  Footprints,
+  Mail,
+  MapPin,
+  Phone,
+  Printer,
+} from "lucide-react";
+
+import styles from "./arrival-map.module.css";
+import {
+  ARRIVAL_ROUTES,
+  CPP_PARKING_SERVICES_URL,
+  PARKING_REGISTRATION_URL,
+  ROUTES_VERIFIED_LABEL,
+  type ArrivalRoute,
+  type ArrivalRouteId,
+} from "./routes";
+
+const routeOrder: ArrivalRouteId[] = ["i10", "sr57", "walk"];
+
+function RouteModeIcon({ route }: { route: ArrivalRoute }) {
+  if (route.mode === "walk") {
+    return <Footprints aria-hidden="true" />;
+  }
+
+  return <CarFront aria-hidden="true" />;
+}
+
+function ExternalAction({
+  href,
+  children,
+  primary = false,
+}: {
+  href: string;
+  children: ReactNode;
+  primary?: boolean;
+}) {
+  return (
+    <a
+      className={primary ? styles.primaryAction : styles.secondaryAction}
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <span>{children}</span>
+      {primary ? (
+        <ArrowRight aria-hidden="true" />
+      ) : (
+        <ExternalLink aria-hidden="true" />
+      )}
+    </a>
+  );
+}
+
+export function ArrivalMapClient({
+  initialRouteId,
+}: {
+  initialRouteId: ArrivalRouteId;
+}) {
+  const [routeId, setRouteId] = useState(initialRouteId);
+  const route = ARRIVAL_ROUTES[routeId];
+
+  useEffect(() => {
+    const restoreRouteFromUrl = () => {
+      const requestedRoute = new URL(window.location.href).searchParams.get(
+        "route"
+      );
+      setRouteId(
+        requestedRoute === "i10" ||
+          requestedRoute === "sr57" ||
+          requestedRoute === "walk"
+          ? requestedRoute
+          : "sr57"
+      );
+    };
+
+    window.addEventListener("popstate", restoreRouteFromUrl);
+    return () => window.removeEventListener("popstate", restoreRouteFromUrl);
+  }, []);
+
+  const selectRoute = (nextRouteId: ArrivalRouteId) => {
+    setRouteId(nextRouteId);
+
+    const nextUrl = new URL(window.location.href);
+    nextUrl.searchParams.set("route", nextRouteId);
+    window.history.pushState(
+      null,
+      "",
+      `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`
+    );
+  };
+
+  return (
+    <main className={styles.page}>
+      <a className={styles.skipLink} href="#arrival-routes">
+        Skip to arrival routes
+      </a>
+
+      <header className={styles.header}>
+        <div className={styles.headerInner}>
+          <div className={styles.brandLockup}>
+            <div className={styles.brandMark} aria-hidden="true">
+              SBP
+            </div>
+            <div>
+              <p className={styles.programName}>
+                NSF CURE Summer Bridge Program
+              </p>
+              <h1>CPP Student Arrival Maps</h1>
+              <p className={styles.headerRoute}>
+                Parking Structure 1 <span aria-hidden="true">→</span>{" "}
+                Building 163
+              </p>
+            </div>
+          </div>
+          <div className={styles.campusLabel}>
+            <strong>Cal Poly Pomona</strong>
+            <span>Plan your drive, parking, and walk.</span>
+          </div>
+        </div>
+      </header>
+
+      <div className={styles.pageContent}>
+        <section
+          className={styles.preparationGrid}
+          aria-labelledby="before-you-leave-title"
+        >
+          <div className={styles.preparationPanel}>
+            <div className={styles.preparationIntro}>
+              <div>
+                <p className={styles.sectionLabel}>Before you leave</p>
+                <h2 id="before-you-leave-title">
+                  Register first, then save your route
+                </h2>
+                <p>
+                  CPP requires valid parking authorization with no grace
+                  period. Parking registration is valid all day on weekdays,
+                  August 6–19, 2026. Register your license plate before
+                  arrival—your plate is your permit.
+                </p>
+              </div>
+              <div className={styles.preparationActions}>
+                <a
+                  className={styles.registrationAction}
+                  href={PARKING_REGISTRATION_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Parking registration
+                  <ArrowRight aria-hidden="true" />
+                </a>
+                <button
+                  className={styles.printAction}
+                  type="button"
+                  onClick={() => window.print()}
+                >
+                  <Printer aria-hidden="true" />
+                  Print directions
+                </button>
+              </div>
+            </div>
+
+            <ol className={styles.preparationSteps}>
+              <li>
+                <span>1</span>
+                <div>
+                  <strong>Register your vehicle</strong>
+                  <p>Use the event link and save the confirmation.</p>
+                </div>
+              </li>
+              <li>
+                <span>2</span>
+                <div>
+                  <strong>Drive to Structure 1</strong>
+                  <p>Enter from Magnolia Lane and follow event signs.</p>
+                </div>
+              </li>
+              <li>
+                <span>3</span>
+                <div>
+                  <strong>Walk to Building 163</strong>
+                  <p>Allow about 8–10 minutes from the structure.</p>
+                </div>
+              </li>
+            </ol>
+
+            <p className={styles.parkingFinePrint}>
+              Park only in locations permitted by your registration and posted
+              signage. Check your itinerary for your arrival time and call
+              Parking Services if the assigned area is full.
+            </p>
+          </div>
+
+          <aside className={styles.destinationPanel} aria-label="Destination">
+            <div className={styles.destinationNumber}>106</div>
+            <div>
+              <p className={styles.sectionLabel}>Your parking destination</p>
+              <h2>Parking Structure 1</h2>
+              <p>Building 106 · Magnolia Lane entrance</p>
+            </div>
+            <div className={styles.accessibilityNote}>
+              <Accessibility aria-hidden="true" />
+              <p>
+                Accessible parking is available in Structure 1. A valid state
+                placard or plate and event registration are required. Need a
+                drop-off arrangement?{" "}
+                <Link href="/contact-us">Contact program staff</Link>.
+              </p>
+            </div>
+          </aside>
+        </section>
+
+        <section
+          className={styles.routeSection}
+          aria-labelledby="active-route-title"
+        >
+          <div
+            className={styles.routeHeadingRow}
+            id="arrival-routes"
+            tabIndex={-1}
+          >
+            <div>
+              <p className={styles.sectionLabel}>{route.eyebrow}</p>
+              <h2 id="active-route-title">{route.title}</h2>
+              <p className={styles.routeDescription}>{route.description}</p>
+            </div>
+            <div className={styles.durationCard}>
+              <strong>{route.duration}</strong>
+              <span>{route.distance}</span>
+            </div>
+          </div>
+
+          <div
+            className={styles.routeSelector}
+            role="group"
+            aria-label="Choose an arrival route"
+          >
+            {routeOrder.map((candidateId) => {
+              const candidate = ARRIVAL_ROUTES[candidateId];
+              const isSelected = candidateId === routeId;
+
+              return (
+                <button
+                  className={`${styles.routeButton} ${
+                    isSelected ? styles.routeButtonSelected : ""
+                  }`}
+                  key={candidateId}
+                  type="button"
+                  aria-label={candidate.tabLabel}
+                  aria-pressed={isSelected}
+                  aria-controls="arrival-route-panel"
+                  onClick={() => selectRoute(candidateId)}
+                >
+                  <span className={styles.routeIcon}>
+                    <RouteModeIcon route={candidate} />
+                  </span>
+                  <span className={styles.desktopTabLabel}>
+                    {candidate.tabLabel}
+                  </span>
+                  <span className={styles.mobileTabLabel} aria-hidden="true">
+                    {candidate.mobileTabLabel}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <p className={styles.srOnly} aria-live="polite" aria-atomic="true">
+            {route.title} selected.
+          </p>
+
+          <div id="arrival-route-panel" className={styles.routePanel}>
+            <div className={styles.endpoints}>
+              <div>
+                <span>A</span>
+                <p>{route.startLabel}</p>
+              </div>
+              <div className={styles.endpointLine} aria-hidden="true" />
+              <div>
+                <span>B</span>
+                <p>{route.endLabel}</p>
+              </div>
+            </div>
+
+            <div className={styles.navigationActions}>
+              <ExternalAction href={route.primaryUrl} primary>
+                {route.primaryLabel}
+              </ExternalAction>
+              <ExternalAction href={route.secondaryUrl}>
+                {route.secondaryLabel}
+              </ExternalAction>
+            </div>
+
+            <div className={styles.mapToolbar}>
+              <div>
+                <MapPin aria-hidden="true" />
+                <span>Live Google route</span>
+              </div>
+              <a href="#written-directions">Skip map to written directions</a>
+            </div>
+
+            <div className={styles.mapFrame}>
+              <iframe
+                key={route.id}
+                src={route.mapUrl}
+                title={route.mapTitle}
+                loading="lazy"
+                referrerPolicy="strict-origin-when-cross-origin"
+              />
+            </div>
+
+            <div className={styles.routeDetailsGrid}>
+              <section
+                className={styles.directionsPanel}
+                id="written-directions"
+                tabIndex={-1}
+                aria-labelledby="written-directions-title"
+              >
+                <div className={styles.panelHeading}>
+                  <div>
+                    <p className={styles.sectionLabel}>Turn by turn</p>
+                    <h3 id="written-directions-title">
+                      {route.directionsTitle}
+                    </h3>
+                  </div>
+                  <ExternalAction href={route.primaryUrl} primary>
+                    Open in Google Maps
+                  </ExternalAction>
+                </div>
+
+                <ol className={styles.directionsList}>
+                  {route.steps.map((step, index) => (
+                    <li key={step.title}>
+                      <span>{index + 1}</span>
+                      <div>
+                        <strong>{step.title}</strong>
+                        <p>{step.description}</p>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              </section>
+
+              <aside
+                className={styles.landmarksPanel}
+                aria-labelledby="landmarks-title"
+              >
+                <p className={styles.sectionLabel}>Look for</p>
+                <h3 id="landmarks-title">Buildings &amp; landmarks</h3>
+                <ul>
+                  {route.landmarks.map((landmark) => (
+                    <li key={landmark}>
+                      <Check aria-hidden="true" />
+                      <span>{landmark}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <div className={styles.routeDestination}>
+                  <div>{route.destinationNumber}</div>
+                  <div>
+                    <p className={styles.sectionLabel}>Destination</p>
+                    <strong>{route.destinationTitle}</strong>
+                    <span>{route.destinationSubtitle}</span>
+                  </div>
+                </div>
+              </aside>
+            </div>
+          </div>
+        </section>
+
+        <footer className={styles.helpPanel}>
+          <div>
+            <p className={styles.sectionLabel}>Arrival help</p>
+            <h2>Keep these contacts with your confirmation</h2>
+            <p>
+              Route details last verified {ROUTES_VERIFIED_LABEL}. Campus roads
+              and pedestrian access can change; always follow posted signs.
+            </p>
+          </div>
+          <div className={styles.contactLinks}>
+            <a href="tel:+19098693061">
+              <Phone aria-hidden="true" />
+              Parking Services: (909) 869-3061
+            </a>
+            <a href="mailto:parking@cpp.edu">
+              <Mail aria-hidden="true" />
+              parking@cpp.edu
+            </a>
+            <a
+              href={CPP_PARKING_SERVICES_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <ExternalLink aria-hidden="true" />
+              Official CPP parking information
+            </a>
+          </div>
+          <p className={styles.safetyNote}>
+            Never read this page while driving. Start navigation before you
+            leave and let a passenger handle route changes.
+          </p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/arrival-map/arrival-map.module.css
+++ b/web/src/app/arrival-map/arrival-map.module.css
@@ -1,0 +1,1178 @@
+.page {
+  --green: #005030;
+  --green-dark: #003d25;
+  --green-soft: #e6f0eb;
+  --gold: #ffb81c;
+  --cream: #f5f3ea;
+  --ink: #18312a;
+  --muted: #5f6f68;
+  --line: #d8d3c3;
+  min-height: 100vh;
+  overflow-x: clip;
+  background: var(--cream);
+  color: var(--ink);
+}
+
+.page *,
+.page *::before,
+.page *::after {
+  box-sizing: border-box;
+}
+
+.page a,
+.page button {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.skipLink {
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 100;
+  translate: 0 -150%;
+  border-radius: 0.4rem;
+  background: #fff;
+  padding: 0.75rem 1rem;
+  color: var(--green-dark);
+  font-weight: 800;
+  box-shadow: 0 5px 18px rgb(0 0 0 / 20%);
+}
+
+.skipLink:focus {
+  translate: 0;
+}
+
+.header {
+  border-bottom: 5px solid var(--gold);
+  background: var(--green);
+  color: #fff;
+}
+
+.headerInner,
+.pageContent {
+  width: min(100% - 2rem, 74rem);
+  margin-inline: auto;
+}
+
+.headerInner {
+  display: flex;
+  min-height: 9.5rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding-block: 1.6rem;
+}
+
+.brandLockup {
+  display: flex;
+  align-items: center;
+  gap: 1.15rem;
+}
+
+.brandMark {
+  display: grid;
+  width: 4.75rem;
+  aspect-ratio: 1;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 2px solid rgb(255 255 255 / 70%);
+  border-radius: 50%;
+  color: var(--gold);
+  font-size: 1.05rem;
+  font-weight: 900;
+  letter-spacing: 0.09em;
+}
+
+.programName,
+.sectionLabel {
+  margin: 0;
+  color: #8d5f00;
+  font-size: 0.73rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.programName {
+  color: #ffcf63;
+}
+
+.header h1 {
+  margin: 0.3rem 0 0;
+  font-size: clamp(1.65rem, 3vw, 2.35rem);
+  font-weight: 850;
+  letter-spacing: -0.035em;
+  line-height: 1.05;
+}
+
+.headerRoute {
+  margin: 0.45rem 0 0;
+  color: rgb(255 255 255 / 80%);
+  font-size: 0.95rem;
+  font-weight: 650;
+}
+
+.headerRoute span {
+  color: var(--gold);
+  padding-inline: 0.25rem;
+}
+
+.campusLabel {
+  display: grid;
+  min-width: 15.5rem;
+  gap: 0.25rem;
+  border-left: 1px solid rgb(255 255 255 / 25%);
+  padding-left: 1.5rem;
+  text-align: right;
+}
+
+.campusLabel strong {
+  color: var(--gold);
+  font-size: 1rem;
+}
+
+.campusLabel span {
+  color: rgb(255 255 255 / 72%);
+  font-size: 0.84rem;
+}
+
+.pageContent {
+  padding-block: 2rem 3rem;
+}
+
+.preparationGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.75fr) minmax(17rem, 0.75fr);
+  gap: 1rem;
+  scroll-margin-top: 1rem;
+}
+
+.preparationPanel,
+.destinationPanel,
+.routeSection,
+.helpPanel {
+  border: 1px solid var(--line);
+  border-radius: 0.75rem;
+  box-shadow: 0 9px 28px rgb(34 54 45 / 7%);
+}
+
+.preparationPanel {
+  overflow: hidden;
+  border-color: var(--green);
+  background: var(--green);
+  color: #fff;
+  padding: clamp(1.3rem, 3vw, 2rem);
+}
+
+.preparationPanel .sectionLabel {
+  color: #ffcf63;
+}
+
+.preparationIntro {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+}
+
+.preparationIntro h2,
+.routeHeadingRow h2,
+.destinationPanel h2,
+.helpPanel h2,
+.panelHeading h3,
+.landmarksPanel h3 {
+  margin: 0.3rem 0 0;
+  color: inherit;
+  font-weight: 850;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+}
+
+.preparationIntro h2 {
+  max-width: 26ch;
+  font-size: clamp(1.35rem, 2.4vw, 1.8rem);
+}
+
+.preparationIntro > div:first-child > p:last-child {
+  max-width: 62ch;
+  margin: 0.75rem 0 0;
+  color: rgb(255 255 255 / 77%);
+  font-size: 0.91rem;
+  line-height: 1.6;
+}
+
+.preparationActions {
+  display: grid;
+  min-width: 12.6rem;
+  gap: 0.55rem;
+}
+
+.registrationAction,
+.printAction,
+.primaryAction,
+.secondaryAction {
+  display: inline-flex;
+  min-height: 3rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  border-radius: 0.45rem;
+  padding: 0.72rem 1rem;
+  font-size: 0.87rem;
+  font-weight: 850;
+  line-height: 1.2;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 140ms ease, color 140ms ease,
+    border-color 140ms ease, transform 140ms ease;
+}
+
+.registrationAction {
+  background: var(--gold);
+  color: #17352b;
+}
+
+.printAction {
+  border: 1px solid rgb(255 255 255 / 45%);
+  background: transparent;
+  color: #fff;
+}
+
+.registrationAction svg,
+.printAction svg,
+.primaryAction svg,
+.secondaryAction svg {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+}
+
+.registrationAction:hover {
+  background: #ffd064;
+}
+
+.printAction:hover {
+  border-color: #fff;
+  background: rgb(255 255 255 / 10%);
+}
+
+.preparationSteps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  margin: 1.6rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.preparationSteps li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 2rem 1fr;
+  gap: 0.7rem;
+  padding-right: 1rem;
+}
+
+.preparationSteps li:not(:last-child)::after {
+  position: absolute;
+  top: 1rem;
+  right: 0.5rem;
+  width: 1px;
+  height: 2.4rem;
+  background: rgb(255 255 255 / 25%);
+  content: "";
+}
+
+.preparationSteps li > span {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border: 1px solid rgb(255 255 255 / 48%);
+  border-radius: 50%;
+  color: var(--gold);
+  font-size: 0.8rem;
+  font-weight: 900;
+}
+
+.preparationSteps strong {
+  display: block;
+  font-size: 0.85rem;
+}
+
+.preparationSteps p {
+  margin: 0.25rem 0 0;
+  color: rgb(255 255 255 / 68%);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.parkingFinePrint {
+  margin: 1.35rem 0 0;
+  border-top: 1px solid rgb(255 255 255 / 18%);
+  padding-top: 0.85rem;
+  color: rgb(255 255 255 / 65%);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.destinationPanel {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  background: #fff;
+  padding: 1.5rem;
+}
+
+.destinationNumber {
+  display: grid;
+  width: 4rem;
+  height: 4rem;
+  place-items: center;
+  border-radius: 0.65rem;
+  background: var(--green-soft);
+  color: var(--green);
+  font-size: 1.45rem;
+  font-weight: 900;
+}
+
+.destinationPanel > div:nth-child(2) {
+  margin-top: 1.15rem;
+}
+
+.destinationPanel h2 {
+  color: var(--ink);
+  font-size: 1.35rem;
+}
+
+.destinationPanel > div:nth-child(2) > p:last-child {
+  margin: 0.45rem 0 0;
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.accessibilityNote {
+  display: grid;
+  grid-template-columns: 1.25rem 1fr;
+  gap: 0.65rem;
+  margin-top: 1.25rem;
+  border-top: 1px solid #ebe7db;
+  padding-top: 1rem;
+  color: var(--muted);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.accessibilityNote svg {
+  width: 1.15rem;
+  color: var(--green);
+}
+
+.accessibilityNote p {
+  margin: 0;
+}
+
+.accessibilityNote a,
+.mapToolbar a {
+  color: var(--green);
+  font-weight: 800;
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.routeSection {
+  margin-top: 1.25rem;
+  overflow: clip;
+  background: #fff;
+}
+
+.routeHeadingRow {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: clamp(1.4rem, 3vw, 2rem);
+  scroll-margin-top: 1rem;
+}
+
+.routeHeadingRow h2 {
+  color: var(--ink);
+  font-size: clamp(1.55rem, 3vw, 2.15rem);
+}
+
+.routeDescription {
+  max-width: 65ch;
+  margin: 0.65rem 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.durationCard {
+  display: grid;
+  min-width: 10rem;
+  gap: 0.18rem;
+  border-left: 3px solid var(--gold);
+  padding-left: 1rem;
+}
+
+.durationCard strong {
+  color: var(--green);
+  font-size: 1rem;
+}
+
+.durationCard span {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.routeSelector {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.55rem;
+  border-block: 1px solid var(--line);
+  background: #eeeadf;
+  padding: 0.7rem;
+}
+
+.routeButton {
+  display: flex;
+  min-height: 3.35rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  border: 1px solid #cdc7b6;
+  border-radius: 0.45rem;
+  background: #fff;
+  color: #385149;
+  padding: 0.65rem 0.85rem;
+  font-size: 0.86rem;
+  font-weight: 850;
+  cursor: pointer;
+  transition: background-color 140ms ease, border-color 140ms ease,
+    color 140ms ease, transform 140ms ease;
+}
+
+.routeButton:hover {
+  border-color: var(--green);
+  background: #f7fbf9;
+  color: var(--green);
+}
+
+.routeButtonSelected,
+.routeButtonSelected:hover {
+  border-color: var(--green);
+  background: var(--green);
+  color: #fff;
+  box-shadow: 0 3px 10px rgb(0 80 48 / 18%);
+}
+
+.routeIcon {
+  display: grid;
+  width: 1.7rem;
+  height: 1.7rem;
+  place-items: center;
+  border-radius: 50%;
+  background: #e8eee9;
+  color: var(--green);
+}
+
+.routeButtonSelected .routeIcon {
+  background: var(--gold);
+  color: var(--green-dark);
+}
+
+.routeIcon svg {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
+.mobileTabLabel {
+  display: none;
+}
+
+.routePanel {
+  padding: clamp(1rem, 2.6vw, 1.75rem);
+}
+
+.endpoints {
+  display: grid;
+  grid-template-columns: auto minmax(2.5rem, 1fr) auto;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.endpoints > div:not(.endpointLine) {
+  display: flex;
+  min-width: 0;
+  max-width: 28rem;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.endpoints > div:last-child {
+  justify-self: end;
+}
+
+.endpoints span {
+  display: grid;
+  width: 1.8rem;
+  height: 1.8rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--green);
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.endpoints > div:last-child span {
+  background: var(--gold);
+  color: var(--green-dark);
+}
+
+.endpoints p {
+  margin: 0;
+  color: #3d514a;
+  font-size: 0.79rem;
+  font-weight: 750;
+}
+
+.endpointLine {
+  height: 1px;
+  background: repeating-linear-gradient(
+    to right,
+    #9aa69f 0,
+    #9aa69f 6px,
+    transparent 6px,
+    transparent 11px
+  );
+}
+
+.navigationActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1.15rem;
+}
+
+.primaryAction {
+  border: 1px solid var(--green);
+  background: var(--green);
+  color: #fff;
+}
+
+.primaryAction:hover {
+  border-color: var(--green-dark);
+  background: var(--green-dark);
+}
+
+.secondaryAction {
+  border: 1px solid #b8c2bc;
+  background: #fff;
+  color: var(--green);
+}
+
+.secondaryAction:hover {
+  border-color: var(--green);
+  background: var(--green-soft);
+}
+
+.mapToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1.4rem;
+  border: 1px solid var(--line);
+  border-bottom: 0;
+  border-radius: 0.55rem 0.55rem 0 0;
+  background: #f5f3eb;
+  padding: 0.7rem 0.85rem;
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
+.mapToolbar > div {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 800;
+}
+
+.mapToolbar svg {
+  width: 1rem;
+  color: var(--green);
+}
+
+.mapFrame {
+  position: relative;
+  height: clamp(29rem, 52svh, 40rem);
+  min-height: 18rem;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 0 0 0.55rem 0.55rem;
+  background: #e9ede9;
+}
+
+.mapFrame iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.routeDetailsGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.65fr) minmax(16.5rem, 0.75fr);
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.directionsPanel,
+.landmarksPanel {
+  border: 1px solid var(--line);
+  border-radius: 0.55rem;
+  background: #fff;
+  padding: clamp(1.15rem, 2.5vw, 1.6rem);
+}
+
+.directionsPanel {
+  scroll-margin-top: 5rem;
+}
+
+.panelHeading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.panelHeading h3,
+.landmarksPanel h3 {
+  color: var(--ink);
+  font-size: 1.25rem;
+}
+
+.panelHeading .primaryAction {
+  min-height: 2.75rem;
+  flex: 0 0 auto;
+  padding-block: 0.6rem;
+}
+
+.directionsList {
+  margin: 1.35rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.directionsList li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 2.1rem 1fr;
+  gap: 0.85rem;
+  min-height: 4.3rem;
+  padding-bottom: 1rem;
+}
+
+.directionsList li:not(:last-child)::before {
+  position: absolute;
+  top: 2.05rem;
+  bottom: 0;
+  left: 1rem;
+  width: 1px;
+  background: #cfd8d2;
+  content: "";
+}
+
+.directionsList li > span {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 2.1rem;
+  height: 2.1rem;
+  place-items: center;
+  border: 1px solid #9eb3a7;
+  border-radius: 50%;
+  background: #f5faf7;
+  color: var(--green);
+  font-size: 0.76rem;
+  font-weight: 900;
+}
+
+.directionsList strong {
+  display: block;
+  color: #263e36;
+  font-size: 0.88rem;
+}
+
+.directionsList p {
+  margin: 0.3rem 0 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.landmarksPanel {
+  background: #f8f7f1;
+}
+
+.landmarksPanel ul {
+  display: grid;
+  gap: 0.85rem;
+  margin: 1.25rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.landmarksPanel li {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: #40554d;
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.landmarksPanel li svg {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--green-soft);
+  padding: 0.15rem;
+  color: var(--green);
+}
+
+.routeDestination {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--line);
+  padding-top: 1.25rem;
+}
+
+.routeDestination > div:first-child {
+  display: grid;
+  width: 3.6rem;
+  height: 3.6rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 0.55rem;
+  background: var(--green);
+  color: var(--gold);
+  font-size: 1.25rem;
+  font-weight: 900;
+}
+
+.routeDestination > div:last-child {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.routeDestination strong {
+  color: var(--ink);
+  font-size: 0.94rem;
+}
+
+.routeDestination span:last-child {
+  color: var(--muted);
+  font-size: 0.74rem;
+}
+
+.helpPanel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(15rem, 0.8fr);
+  gap: 1.25rem 2rem;
+  margin-top: 1.25rem;
+  background: #fff;
+  padding: clamp(1.3rem, 3vw, 2rem);
+}
+
+.helpPanel h2 {
+  color: var(--ink);
+  font-size: 1.25rem;
+}
+
+.helpPanel > div:first-child > p:last-child {
+  max-width: 62ch;
+  margin: 0.6rem 0 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+
+.contactLinks {
+  display: grid;
+  align-content: start;
+  gap: 0.7rem;
+}
+
+.contactLinks a {
+  display: flex;
+  min-height: 2.5rem;
+  align-items: center;
+  gap: 0.65rem;
+  color: var(--green);
+  font-size: 0.82rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.contactLinks a:hover {
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.contactLinks svg {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+}
+
+.safetyNote {
+  grid-column: 1 / -1;
+  margin: 0;
+  border-top: 1px solid #ebe7dc;
+  padding-top: 1rem;
+  color: #6e5841;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.page :is(a, button):focus-visible {
+  outline: 3px solid #0b5fa5;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px #fff;
+}
+
+.page :is(section, main, .routeHeadingRow):focus-visible {
+  outline: 3px solid #0b5fa5;
+  outline-offset: -3px;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+@media (max-width: 900px) {
+  .preparationGrid,
+  .routeDetailsGrid,
+  .helpPanel {
+    grid-template-columns: 1fr;
+  }
+
+  .destinationPanel {
+    display: grid;
+    grid-template-columns: 4rem 1fr;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .destinationPanel > div:nth-child(2) {
+    margin-top: 0;
+  }
+
+  .accessibilityNote {
+    grid-column: 1 / -1;
+    margin-top: 0.5rem;
+  }
+
+  .helpPanel .safetyNote {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 680px) {
+  .headerInner,
+  .pageContent {
+    width: min(100% - 1.25rem, 74rem);
+  }
+
+  .headerInner {
+    min-height: 8.2rem;
+    padding-block: 1.25rem;
+  }
+
+  .brandLockup {
+    gap: 0.85rem;
+  }
+
+  .brandMark {
+    width: 3.5rem;
+    font-size: 0.82rem;
+  }
+
+  .campusLabel {
+    display: none;
+  }
+
+  .header h1 {
+    font-size: clamp(1.4rem, 6.4vw, 1.75rem);
+  }
+
+  .headerRoute {
+    font-size: 0.8rem;
+  }
+
+  .pageContent {
+    padding-block: 0.75rem 1.5rem;
+  }
+
+  .preparationGrid {
+    gap: 0.65rem;
+  }
+
+  .preparationPanel,
+  .destinationPanel,
+  .routeSection,
+  .helpPanel {
+    border-radius: 0.6rem;
+  }
+
+  .preparationIntro {
+    display: grid;
+    gap: 1.15rem;
+  }
+
+  .preparationActions {
+    grid-template-columns: 1fr 1fr;
+    min-width: 0;
+  }
+
+  .preparationSteps {
+    grid-template-columns: 1fr;
+    gap: 0.9rem;
+    margin-top: 1.35rem;
+  }
+
+  .preparationSteps li {
+    padding-right: 0;
+  }
+
+  .preparationSteps li:not(:last-child)::after {
+    top: 2rem;
+    right: auto;
+    bottom: -0.8rem;
+    left: 1rem;
+    height: auto;
+  }
+
+  .routeHeadingRow {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .durationCard {
+    min-width: 0;
+  }
+
+  .routeSelector {
+    gap: 0.35rem;
+    padding: 0.5rem;
+  }
+
+  .routeButton {
+    min-width: 0;
+    min-height: 3.5rem;
+    gap: 0.4rem;
+    padding: 0.55rem 0.35rem;
+  }
+
+  .desktopTabLabel {
+    display: none;
+  }
+
+  .mobileTabLabel {
+    display: inline;
+  }
+
+  .routePanel {
+    padding-inline: 0.65rem;
+  }
+
+  .endpoints {
+    grid-template-columns: 1fr;
+    gap: 0.55rem;
+    padding-inline: 0.25rem;
+  }
+
+  .endpoints > div:last-child {
+    justify-self: start;
+  }
+
+  .endpointLine {
+    width: 1px;
+    height: 1rem;
+    margin-left: 0.9rem;
+    background: repeating-linear-gradient(
+      to bottom,
+      #9aa69f 0,
+      #9aa69f 4px,
+      transparent 4px,
+      transparent 7px
+    );
+  }
+
+  .navigationActions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .mapToolbar {
+    align-items: flex-start;
+    font-size: 0.7rem;
+  }
+
+  .mapToolbar > div {
+    white-space: nowrap;
+  }
+
+  .mapToolbar a {
+    text-align: right;
+  }
+
+  .mapFrame {
+    height: clamp(24rem, 50svh, 29rem);
+  }
+
+  .panelHeading {
+    align-items: flex-start;
+  }
+
+  .panelHeading .primaryAction {
+    display: none;
+  }
+
+  .helpPanel {
+    gap: 1.1rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .programName {
+    letter-spacing: 0.08em;
+  }
+
+  .preparationActions,
+  .navigationActions {
+    grid-template-columns: 1fr;
+  }
+
+  .registrationAction,
+  .printAction,
+  .primaryAction,
+  .secondaryAction {
+    width: 100%;
+  }
+
+  .destinationPanel {
+    grid-template-columns: 3.5rem 1fr;
+  }
+
+  .destinationNumber {
+    width: 3.5rem;
+    height: 3.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page *,
+  .page *::before,
+  .page *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media print {
+  .page {
+    min-height: 0;
+    background: #fff;
+  }
+
+  .header {
+    border-bottom-width: 3px;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .headerInner,
+  .pageContent {
+    width: 100%;
+  }
+
+  .headerInner {
+    min-height: 0;
+    padding: 0.8rem;
+  }
+
+  .brandMark,
+  .campusLabel,
+  .preparationActions,
+  .routeSelector,
+  .navigationActions,
+  .mapToolbar,
+  .mapFrame,
+  .accessibilityNote {
+    display: none;
+  }
+
+  .pageContent {
+    padding: 0.8rem;
+  }
+
+  .preparationPanel,
+  .destinationPanel,
+  .routeSection,
+  .directionsPanel,
+  .landmarksPanel {
+    box-shadow: none;
+    break-inside: avoid;
+  }
+
+  .preparationGrid,
+  .routeDetailsGrid {
+    grid-template-columns: 2fr 1fr;
+  }
+
+  .preparationPanel {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .routeSection {
+    margin-top: 0.8rem;
+  }
+
+  .helpPanel {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    margin-top: 0.8rem;
+    padding: 0.8rem;
+  }
+
+  .routeHeadingRow,
+  .routePanel,
+  .directionsPanel,
+  .landmarksPanel {
+    padding: 0.8rem;
+  }
+
+  .directionsList li {
+    min-height: 0;
+    padding-bottom: 0.55rem;
+  }
+}

--- a/web/src/app/arrival-map/page.tsx
+++ b/web/src/app/arrival-map/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next";
 
+import { ArrivalMapClient } from "./ArrivalMapClient";
+import { isArrivalRouteId } from "./routes";
+
 export const metadata: Metadata = {
-  title: "Student Arrival Map",
+  title: "Student Arrival Maps",
   description:
-    "Private-by-link driving and walking directions for NSF CURE Summer Bridge Program participants.",
+    "Unlisted driving, parking, and walking directions for NSF CURE Summer Bridge Program participants.",
   robots: {
     index: false,
     follow: false,
@@ -16,69 +19,20 @@ export const metadata: Metadata = {
   },
 };
 
-const arrivalMapUrl =
-  "https://cpp-student-arrival-maps.ajokonkwo.chatgpt.site";
+type ArrivalMapPageProps = {
+  searchParams: Promise<{ route?: string | string[] }>;
+};
 
-export default function ArrivalMapPage() {
-  return (
-    <main className="min-h-screen bg-[#f5f3ea] text-slate-950">
-      <header className="border-b-4 border-[#ffb81c] bg-[#005030] px-4 py-4 text-white shadow-sm sm:px-6">
-        <div className="mx-auto flex max-w-7xl items-center justify-between gap-4">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#ffcf63]">
-              NSF CURE Summer Bridge Program
-            </p>
-            <h1 className="mt-1 text-xl font-bold sm:text-2xl">
-              Student Arrival Map
-            </h1>
-          </div>
-          <a
-            href={arrivalMapUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="shrink-0 rounded-md bg-[#ffb81c] px-4 py-2 text-sm font-bold text-[#17352b] transition hover:bg-[#ffd36d] focus-visible:outline-white"
-          >
-            Open full screen
-          </a>
-        </div>
-      </header>
+export default async function ArrivalMapPage({
+  searchParams,
+}: ArrivalMapPageProps) {
+  const params = await searchParams;
+  const requestedRoute = Array.isArray(params.route)
+    ? params.route[0]
+    : params.route;
+  const initialRouteId = isArrivalRouteId(requestedRoute)
+    ? requestedRoute
+    : "sr57";
 
-      <section
-        className="mx-auto max-w-7xl px-3 py-3 sm:px-6 sm:py-5"
-        aria-label="Interactive CPP arrival map"
-      >
-        <div className="mb-3 rounded-md border border-[#d9d2bd] bg-white px-4 py-3 text-sm text-slate-700 shadow-sm">
-          Choose the route for your freeway exit, or use the walking directions
-          from Parking Structure 1 to Building 163. For turn-by-turn navigation,
-          use the Google Maps button inside each route.
-        </div>
-
-        <div className="overflow-hidden rounded-lg border border-[#c9c1aa] bg-white shadow-lg">
-          <iframe
-            src={arrivalMapUrl}
-            title="CPP student driving and walking arrival maps"
-            className="h-[calc(100vh-12.5rem)] min-h-[620px] w-full"
-            loading="eager"
-            referrerPolicy="strict-origin-when-cross-origin"
-            allow="geolocation"
-          />
-        </div>
-
-        <noscript>
-          <p className="mt-4 rounded-md bg-white p-4 text-center">
-            JavaScript is required for the interactive map.{" "}
-            <a
-              href={arrivalMapUrl}
-              className="font-semibold underline"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Open the arrival map directly
-            </a>
-            .
-          </p>
-        </noscript>
-      </section>
-    </main>
-  );
+  return <ArrivalMapClient initialRouteId={initialRouteId} />;
 }

--- a/web/src/app/arrival-map/page.tsx
+++ b/web/src/app/arrival-map/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Student Arrival Map",
+  description:
+    "Private-by-link driving and walking directions for NSF CURE Summer Bridge Program participants.",
+  robots: {
+    index: false,
+    follow: false,
+    nocache: true,
+    googleBot: {
+      index: false,
+      follow: false,
+      noimageindex: true,
+    },
+  },
+};
+
+const arrivalMapUrl =
+  "https://cpp-student-arrival-maps.ajokonkwo.chatgpt.site";
+
+export default function ArrivalMapPage() {
+  return (
+    <main className="min-h-screen bg-[#f5f3ea] text-slate-950">
+      <header className="border-b-4 border-[#ffb81c] bg-[#005030] px-4 py-4 text-white shadow-sm sm:px-6">
+        <div className="mx-auto flex max-w-7xl items-center justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#ffcf63]">
+              NSF CURE Summer Bridge Program
+            </p>
+            <h1 className="mt-1 text-xl font-bold sm:text-2xl">
+              Student Arrival Map
+            </h1>
+          </div>
+          <a
+            href={arrivalMapUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="shrink-0 rounded-md bg-[#ffb81c] px-4 py-2 text-sm font-bold text-[#17352b] transition hover:bg-[#ffd36d] focus-visible:outline-white"
+          >
+            Open full screen
+          </a>
+        </div>
+      </header>
+
+      <section
+        className="mx-auto max-w-7xl px-3 py-3 sm:px-6 sm:py-5"
+        aria-label="Interactive CPP arrival map"
+      >
+        <div className="mb-3 rounded-md border border-[#d9d2bd] bg-white px-4 py-3 text-sm text-slate-700 shadow-sm">
+          Choose the route for your freeway exit, or use the walking directions
+          from Parking Structure 1 to Building 163. For turn-by-turn navigation,
+          use the Google Maps button inside each route.
+        </div>
+
+        <div className="overflow-hidden rounded-lg border border-[#c9c1aa] bg-white shadow-lg">
+          <iframe
+            src={arrivalMapUrl}
+            title="CPP student driving and walking arrival maps"
+            className="h-[calc(100vh-12.5rem)] min-h-[620px] w-full"
+            loading="eager"
+            referrerPolicy="strict-origin-when-cross-origin"
+            allow="geolocation"
+          />
+        </div>
+
+        <noscript>
+          <p className="mt-4 rounded-md bg-white p-4 text-center">
+            JavaScript is required for the interactive map.{" "}
+            <a
+              href={arrivalMapUrl}
+              className="font-semibold underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open the arrival map directly
+            </a>
+            .
+          </p>
+        </noscript>
+      </section>
+    </main>
+  );
+}

--- a/web/src/app/arrival-map/routes.ts
+++ b/web/src/app/arrival-map/routes.ts
@@ -1,0 +1,223 @@
+export type ArrivalRouteId = "i10" | "sr57" | "walk";
+
+export type ArrivalRouteStep = {
+  title: string;
+  description: string;
+};
+
+export type ArrivalRoute = {
+  id: ArrivalRouteId;
+  mode: "drive" | "walk";
+  tabLabel: string;
+  mobileTabLabel: string;
+  eyebrow: string;
+  title: string;
+  description: string;
+  duration: string;
+  distance: string;
+  startLabel: string;
+  endLabel: string;
+  mapUrl: string;
+  mapTitle: string;
+  primaryLabel: string;
+  primaryUrl: string;
+  secondaryLabel: string;
+  secondaryUrl: string;
+  directionsTitle: string;
+  steps: ArrivalRouteStep[];
+  landmarks: string[];
+  destinationNumber: "106" | "163";
+  destinationTitle: string;
+  destinationSubtitle: string;
+};
+
+// Parking portal destination and official CPP powered-door entrance pins.
+const PARKING_COORDINATES = "34.060554%2C-117.816389";
+const BUILDING_163_COORDINATES = "34.061321%2C-117.820030";
+const I10_ENTRY_COORDINATES = "34.0627957%2C-117.8118201";
+const SR57_ENTRY_COORDINATES = "34.047829%2C-117.810358";
+
+const parkingFromCurrentLocation =
+  `https://www.google.com/maps/dir/?api=1&destination=${PARKING_COORDINATES}&travelmode=driving&dir_action=navigate`;
+const buildingFromCurrentLocation =
+  `https://www.google.com/maps/dir/?api=1&destination=${BUILDING_163_COORDINATES}&travelmode=walking&dir_action=navigate`;
+
+export const PARKING_REGISTRATION_URL =
+  "https://www.offstreet.io/events/UWJ8K7KQ";
+export const CPP_PARKING_SERVICES_URL = "https://www.cpp.edu/parking/";
+export const ROUTES_VERIFIED_LABEL = "July 30, 2026";
+
+export const ARRIVAL_ROUTES: Record<ArrivalRouteId, ArrivalRoute> = {
+  i10: {
+    id: "i10",
+    mode: "drive",
+    tabLabel: "From I-10",
+    mobileTabLabel: "I-10",
+    eyebrow: "Driving route",
+    title: "From I-10 via Kellogg Drive",
+    description:
+      "Use the Kellogg Drive exit from I-10, then follow the signed campus approach to Parking Structure 1.",
+    duration: "About 5 min on campus",
+    distance: "Campus entrance to parking",
+    startLabel: "Kellogg Drive entrance · near Rose Float Lab",
+    endLabel: "Parking Structure 1 · Building 106",
+    mapUrl:
+      `https://www.google.com/maps?saddr=${I10_ENTRY_COORDINATES}&daddr=${PARKING_COORDINATES}&dirflg=d&output=embed&hl=en`,
+    mapTitle: "I-10 campus entrance to Parking Structure 1 map",
+    primaryLabel: "Navigate to parking",
+    primaryUrl: parkingFromCurrentLocation,
+    secondaryLabel: "Preview campus approach",
+    secondaryUrl:
+      `https://www.google.com/maps/dir/?api=1&origin=${I10_ENTRY_COORDINATES}&destination=${PARKING_COORDINATES}&travelmode=driving`,
+    directionsTitle: "Campus directions",
+    steps: [
+      {
+        title: "Continue on East Campus Drive",
+        description:
+          "Follow the perimeter road northeast from the Kellogg Drive campus entrance.",
+      },
+      {
+        title: "Turn right: South Campus Drive",
+        description: "Continue around the east and south edge of campus.",
+      },
+      {
+        title: "Turn right: Kellogg Drive",
+        description: "Stay on Kellogg Drive when the road bends right.",
+      },
+      {
+        title: "Turn left: South University Drive",
+        description: "Use the signed campus road toward the F-series lots.",
+      },
+      {
+        title: "Turn left: Magnolia Lane",
+        description: "The entrance to Parking Structure 1 is on the left.",
+      },
+    ],
+    landmarks: [
+      "Campus welcome marquee",
+      "South Campus Drive",
+      "Red Gum Lane",
+      "Magnolia Lane",
+    ],
+    destinationNumber: "106",
+    destinationTitle: "Parking Structure 1",
+    destinationSubtitle: "Magnolia Lane entrance",
+  },
+  sr57: {
+    id: "sr57",
+    mode: "drive",
+    tabLabel: "From SR-57",
+    mobileTabLabel: "SR-57",
+    eyebrow: "Driving route",
+    title: "From SR-57 via Temple Avenue",
+    description:
+      "Use the Temple Avenue exit from either direction on SR-57, then follow the campus approach to Parking Structure 1.",
+    duration: "About 5 min on campus",
+    distance: "Campus entrance to parking",
+    startLabel: "Temple Ave & Pomona Blvd",
+    endLabel: "Parking Structure 1 · Building 106",
+    mapUrl:
+      `https://www.google.com/maps?saddr=${SR57_ENTRY_COORDINATES}&daddr=${PARKING_COORDINATES}&dirflg=d&output=embed&hl=en`,
+    mapTitle: "SR-57 Temple Avenue approach to Parking Structure 1 map",
+    primaryLabel: "Navigate to parking",
+    primaryUrl: parkingFromCurrentLocation,
+    secondaryLabel: "Preview campus approach",
+    secondaryUrl:
+      `https://www.google.com/maps/dir/?api=1&origin=${SR57_ENTRY_COORDINATES}&destination=${PARKING_COORDINATES}&travelmode=driving`,
+    directionsTitle: "Campus directions",
+    steps: [
+      {
+        title: "Continue west: Temple Avenue",
+        description:
+          "Turn left from SR-57 North or right from SR-57 South.",
+      },
+      {
+        title: "Turn right: South Campus Drive",
+        description:
+          "The CPP campus and welcome marquee will be on your right.",
+      },
+      {
+        title: "Turn left: Kellogg Drive",
+        description:
+          "Use the second lane from the left at the intersection.",
+      },
+      {
+        title: "Stay right on Kellogg Drive",
+        description: "Continue past the Red Gum Lane intersection.",
+      },
+      {
+        title: "Left: South University, then Magnolia",
+        description: "Turn left again into Parking Structure 1.",
+      },
+    ],
+    landmarks: [
+      "Temple Avenue exit",
+      "Campus welcome marquee",
+      "Kellogg Field",
+      "Red Gum Lane",
+    ],
+    destinationNumber: "106",
+    destinationTitle: "Parking Structure 1",
+    destinationSubtitle: "Magnolia Lane entrance",
+  },
+  walk: {
+    id: "walk",
+    mode: "walk",
+    tabLabel: "Walk to Building 163",
+    mobileTabLabel: "Walk",
+    eyebrow: "Walking route",
+    title: "Parking Structure 1 to Building 163",
+    description:
+      "A mostly flat walk from the parking structure to the College of Business Administration classrooms.",
+    duration: "About 8–10 min",
+    distance: "Approx. 0.3–0.4 mi",
+    startLabel: "Parking Structure 1 · Building 106",
+    endLabel: "Building 163 · CBA classrooms",
+    mapUrl:
+      `https://www.google.com/maps?saddr=${PARKING_COORDINATES}&daddr=${BUILDING_163_COORDINATES}&dirflg=w&output=embed&hl=en`,
+    mapTitle: "Parking Structure 1 to Building 163 walking map",
+    primaryLabel: "Open walking route",
+    primaryUrl:
+      `https://www.google.com/maps/dir/?api=1&origin=${PARKING_COORDINATES}&destination=${BUILDING_163_COORDINATES}&travelmode=walking`,
+    secondaryLabel: "Navigate from my location",
+    secondaryUrl: buildingFromCurrentLocation,
+    directionsTitle: "Walking directions",
+    steps: [
+      {
+        title: "Exit toward Oak Lane",
+        description:
+          "Use the pedestrian path along the south side of Structure 1.",
+      },
+      {
+        title: "Follow Oak Lane west",
+        description: "Continue around the structure toward Red Gum Lane.",
+      },
+      {
+        title: "Turn right: Red Gum Lane",
+        description: "Walk north using the marked pedestrian route.",
+      },
+      {
+        title: "Turn left: South University Drive",
+        description:
+          "Follow the paved walkway west toward the CBA complex.",
+      },
+      {
+        title: "Look for Building 163",
+        description: "The classroom building is beside the Rose Garden.",
+      },
+    ],
+    landmarks: [
+      "Voorhis Alumni Park",
+      "Aratani Japanese Garden",
+      "Rose Garden",
+      "CBA complex",
+    ],
+    destinationNumber: "163",
+    destinationTitle: "Building 163",
+    destinationSubtitle: "CBA classroom building",
+  },
+};
+
+export const isArrivalRouteId = (
+  value: string | undefined
+): value is ArrivalRouteId => value === "i10" || value === "sr57" || value === "walk";

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -18,7 +18,6 @@ export default function robots(): MetadataRoute.Robots {
           "/check-email",
           "/settings",
           "/profile",
-          "/arrival-map",
         ],
       },
     ],

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -18,6 +18,7 @@ export default function robots(): MetadataRoute.Robots {
           "/check-email",
           "/settings",
           "/profile",
+          "/arrival-map",
         ],
       },
     ],


### PR DESCRIPTION
## What changed

- adds a standalone, mobile-friendly `/arrival-map` page
- embeds the completed CPP arrival-map experience
- keeps the route out of the normal navigation and existing sitemap
- adds page-level `noindex, nofollow` metadata
- excludes `/arrival-map` in `robots.txt`
- includes a full-screen fallback link and a no-JavaScript fallback

## Why

Summer Bridge Program students need one shareable CPP-domain URL for both freeway approaches and the walk from Parking Structure 1 to Building 163, without publishing the page in the normal website navigation.

## Privacy note

This is unlisted/private-by-link, not authenticated access. Anyone who receives the exact URL can open or forward it.

## Validation

- verified both changed files on the remote branch
- confirmed `/arrival-map` is not part of the static sitemap route list
- left this PR as a draft for review before deployment